### PR TITLE
Remove intermediate error implementation class

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -39,6 +39,7 @@
                              (:file "immutable-map")
                              (:file "immutable-listmap")
                              (:file "package")))
+               (:file "source-error")
                (:file "error")
                (:module "parser"
                 :serial t

--- a/src/analysis/analysis.lisp
+++ b/src/analysis/analysis.lisp
@@ -17,102 +17,92 @@
 
 (in-package #:coalton-impl/analysis/analysis)
 
-(define-condition non-exhaustive-match-warning (error:coalton-base-warning)
+(define-condition non-exhaustive-match-warning (error:coalton-warning)
   ())
 
-(define-condition useless-pattern-warning (error:coalton-base-warning)
+(define-condition useless-pattern-warning (error:coalton-warning)
   ())
 
-(define-condition pattern-var-matches-constructor (error:coalton-base-warning)
+(define-condition pattern-var-matches-constructor (error:coalton-warning)
   ())
 
-(defun check-pattern-exhaustiveness (pattern env file)
+(defun check-pattern-exhaustiveness (pattern env)
   (declare (type tc:pattern pattern)
-           (type tc:environment env)
-           (type error:coalton-file file))
+           (type tc:environment env))
 
   (let ((missing (find-non-matching-value (list (list pattern)) 1 env)))
     (unless (eq t missing)
       (error 'tc:tc-error
-             :err (error:coalton-error
-                   :file file
-                   :span (tc:pattern-source pattern)
-                   :message "Non-exhaustive match"
-                   :primary-note (format nil "Missing case ~W"
-                                         (print-pattern (first missing))))))))
+             :location (tc:pattern-source pattern)
+             :message "Non-exhaustive match"
+             :primary-note (format nil "Missing case ~W"
+                                   (print-pattern (first missing)))))))
 
-(defun analyze-translation-unit (translation-unit env file)
+(defun analyze-translation-unit (translation-unit env)
   "Perform analysis passes on TRANSLATION-UNIT, potentially producing errors or warnings."
   (declare (type tc:translation-unit translation-unit)
-           (type tc:environment env)
-           (type error:coalton-file file))
+           (type tc:environment env))
 
   (let ((analysis-traverse-block
           (tc:make-traverse-block
            :match (lambda (node)
                     (let ((patterns (mapcar #'tc:node-match-branch-pattern (tc:node-match-branches node))))
                       (loop :for pattern :in patterns
-                            :do (check-for-var-matching-constructor pattern env file))
+                            :do (check-for-var-matching-constructor pattern env))
                       
                       (let ((exhaustive-or-missing
                               (find-non-matching-value (mapcar #'list patterns) 1 env)))
                         (unless (eq t exhaustive-or-missing)
                           (warn 'non-exhaustive-match-warning
-                                :err (error:coalton-error
-                                      :type :warn
-                                      :file file
-                                      :span (tc:node-source node)
-                                      :message "Non-exhaustive match"
-                                      :primary-note "non-exhaustive match"
-                                      :notes (when (first exhaustive-or-missing)
-                                               (list
-                                                (error:make-coalton-error-note
-                                                 :type :secondary
-                                                 :span (tc:node-source node)
-                                                 :message (format nil "Missing case ~W"
-                                                                  (print-pattern (first exhaustive-or-missing)))))))))
+                                :location (tc:node-source node)
+                                :message "Non-exhaustive match"
+                                :primary-note "non-exhaustive match"
+                                :notes (when (first exhaustive-or-missing)
+                                         (list
+                                          (source-error:make-note
+                                           :type :secondary
+                                           :location (tc:node-source node)
+                                           :message (format nil "Missing case ~W"
+                                                            (print-pattern (first exhaustive-or-missing))))))))
                         (loop :for pattern :in patterns
                               :unless (useful-pattern-p patterns pattern env) :do
                                 (warn 'useless-pattern-warning
-                                      :err (error:coalton-error
-                                            :type :warn
-                                            :file file
-                                            :span (tc:pattern-source pattern)
-                                            :message "Useless match case"
-                                            :primary-note "useless match case"
-                                            :notes
-                                            (list
-                                             (error:make-coalton-error-note
-                                              :type :secondary
-                                              :span (tc:node-source node)
-                                              :message "in this match")))))))
+                                      :location (tc:pattern-source pattern)
+                                      :message "Useless match case"
+                                      :primary-note "useless match case"
+                                      :notes
+                                      (list
+                                       (source-error:make-note
+                                        :type :secondary
+                                        :location (tc:node-source node)
+                                        :message "in this match"))))))
                     node)
            :abstraction (lambda (node)
                           (declare (type tc:node-abstraction node))
                           (loop :for pattern :in (tc:node-abstraction-params node)
-                                :do (check-pattern-exhaustiveness pattern env file))
+                                :do (check-pattern-exhaustiveness pattern env))
                           node)
            :bind (lambda (node)
                    (declare (type tc:node-bind node))
-                   (check-pattern-exhaustiveness (tc:node-bind-pattern node) env file)
+                   (check-pattern-exhaustiveness (tc:node-bind-pattern node) env)
                    node))))
 
     ;; Run analysis on definitions
     (loop :for define :in (tc:translation-unit-definitions translation-unit)
           :do (tc:traverse (tc:toplevel-define-body define) analysis-traverse-block)
-          :do (find-unused-variables define file)
-          :do (find-underapplied-values define file)
+          :do (find-unused-variables define)
+          :do (find-underapplied-values define)
           :do (loop :for pattern :in (tc:binding-parameters define)
-                    :do (check-pattern-exhaustiveness pattern env file)))
+                    :do (check-pattern-exhaustiveness pattern env)))
 
     ;; Run analysis on instance definitions
     (loop :for instance :in (tc:translation-unit-instances translation-unit) :do
       (loop :for method :being :the :hash-value :of (tc:toplevel-define-instance-methods instance)
             :do (tc:traverse (tc:instance-method-definition-body method) analysis-traverse-block)
-            :do (find-underapplied-values method file)
-            :do (find-underapplied-values method file)
+            :do (find-underapplied-values method)
+            :do (find-underapplied-values method)
             :do (loop :for pattern :in (tc:binding-parameters method)
-                      :do (check-pattern-exhaustiveness pattern env file))))))
+                      :do (check-pattern-exhaustiveness pattern env))))))
 
 (defgeneric print-pattern (pat)
   (:method ((pat tc:pattern-constructor))
@@ -121,27 +111,23 @@
   (:method ((pat tc:pattern-wildcard))
     "_"))
 
-(defgeneric check-for-var-matching-constructor (pat env file)
-  (:method ((pat tc:pattern-var) env file)
-    (declare (type tc:environment env)
-             (type error:coalton-file file))
+(defgeneric check-for-var-matching-constructor (pat env)
+  (:method ((pat tc:pattern-var) env)
+    (declare (type tc:environment env))
 
     (let ((ctor (tc:lookup-constructor env (tc:pattern-var-orig-name pat) :no-error t)))
       (when ctor
         (warn 'pattern-var-matches-constructor
-              :err (error:coalton-error
-                    :type :warn
-                    :file file
-                    :span (tc:pattern-source pat)
-                    :message "Pattern warning"
-                    :primary-note "pattern variable matches constructor name")))))
+              :location (tc:pattern-source pat)
+              :message "Pattern warning"
+              :primary-note "pattern variable matches constructor name"))))
 
-  (:method ((pat tc:pattern-literal) env file)
-    (declare (ignore env file)))
+  (:method ((pat tc:pattern-literal) env)
+    (declare (ignore env)))
 
-  (:method ((pat tc:pattern-wildcard) env file)
-    (declare (ignore env file)))
+  (:method ((pat tc:pattern-wildcard) env)
+    (declare (ignore env)))
 
-  (:method ((pat tc:pattern-constructor) env file)
+  (:method ((pat tc:pattern-constructor) env)
     (loop :for pat :in (tc:pattern-constructor-patterns pat)
-          :do (check-for-var-matching-constructor pat env file))))
+          :do (check-for-var-matching-constructor pat env))))

--- a/src/analysis/underapplied-values.lisp
+++ b/src/analysis/underapplied-values.lisp
@@ -11,10 +11,10 @@
 
 (in-package #:coalton-impl/analysis/underapplied-values)
 
-(define-condition underapplied-value-warning (error:coalton-base-warning)
+(define-condition underapplied-value-warning (error:coalton-warning)
   ())
 
-(defun find-underapplied-values (binding file)
+(defun find-underapplied-values (binding)
   (tc:traverse
    (tc:binding-value binding)
    (tc:make-traverse-block
@@ -25,11 +25,8 @@
                   :when (and (typep elem 'tc:node)
                              (tc:function-type-p (tc:qualified-ty-type (tc:node-type elem))))
                     :do (warn 'underapplied-value-warning
-                              :err (error:coalton-error
-                                    :type :warn
-                                    :file file
-                                    :span (tc:node-source elem)
-                                    :message "Value may be underapplied"
-                                    :primary-note "discard explicitly with (let _ = ...) to ignore this warning")))
+                              :location (tc:node-source elem)
+                              :message "Value may be underapplied"
+                              :primary-note "discard explicitly with (let _ = ...) to ignore this warning"))
 
             node))))

--- a/src/analysis/unused-variables.lisp
+++ b/src/analysis/unused-variables.lisp
@@ -12,12 +12,11 @@
 
 (in-package #:coalton-impl/analysis/unused-variables)
 
-(define-condition unused-variable-warning (error:coalton-base-warning)
+(define-condition unused-variable-warning (error:coalton-warning)
   ())
 
-(defun find-unused-variables (binding file)
-  (declare (type (or tc:toplevel-define tc:instance-method-definition) binding)
-           (type error:coalton-file file))
+(defun find-unused-variables (binding)
+  (declare (type (or tc:toplevel-define tc:instance-method-definition) binding))
 
   (let ((used-variables (make-hash-table :test #'eq)))
 
@@ -33,7 +32,7 @@
 
     ;; Check for unused parameters in the binding
     (loop :for var :in (tc:pattern-variables (tc:binding-parameters binding))
-          :do (variable-binding var used-variables file))
+          :do (variable-binding var used-variables))
 
     ;; Check for unused variables in the body
     (tc:traverse
@@ -42,33 +41,32 @@
       :bind (lambda (node)
               (declare (type tc:node-bind))
               (loop :for var :in (tc:pattern-variables (tc:node-bind-pattern node))
-                    :do (variable-binding var used-variables file))
+                    :do (variable-binding var used-variables))
               node)
       :do-bind (lambda (node)
                  (declare (type tc:node-do-bind))
                  (loop :for var :in (tc:pattern-variables (tc:node-do-bind-pattern node))
-                       :do (variable-binding var used-variables file))
+                       :do (variable-binding var used-variables))
                  node)
       :match-branch (lambda (node)
                       (declare (type tc:node-match-branch))
                       (loop :for var :in (tc:pattern-variables (tc:node-match-branch-pattern node))
-                            :do (variable-binding var used-variables file))
+                            :do (variable-binding var used-variables))
                       node)
       :let (lambda (node)
              (declare (type tc:node-let node))
              (loop :for binding :in (tc:node-let-bindings node)
-                   :do (variable-binding (tc:node-let-binding-name binding) used-variables file))
+                   :do (variable-binding (tc:node-let-binding-name binding) used-variables))
              node)
       :abstraction (lambda (node)
                      (declare (type tc:node-abstraction node))
                      (loop :for var :in (tc:pattern-variables (tc:node-abstraction-params node))
-                           :do (variable-binding var used-variables file))
+                           :do (variable-binding var used-variables))
                      node)))))
 
-(defun variable-binding (var used-variables file)
+(defun variable-binding (var used-variables)
   (declare (type (or tc:node-variable tc:pattern-var) var)
-           (type hash-table used-variables)
-           (type error:coalton-file file))
+           (type hash-table used-variables))
 
   (destructuring-bind (name . source)
       (etypecase var
@@ -82,18 +80,15 @@
           (tc:pattern-source var))))
 
     (unless (char= (aref (symbol-name name) 0) #\_)
-        (unless (gethash name used-variables)
-          (warn 'unused-variable-warning
-                :err (error:coalton-error
-                      :type :warn
-                      :file file
-                      :span source
-                      :message "Unused variable"
-                      :primary-note "variable defined here"
-                      :help-notes
-                      (list
-                       (error:make-coalton-error-help
-                        :span source
-                        :replacement (lambda (name)
-                                       (concatenate 'string "_" name))
-                        :message "prefix the variable with '_' to declare it unused"))))))))
+      (unless (gethash name used-variables)
+        (warn 'unused-variable-warning
+              :location source
+              :message "Unused variable"
+              :primary-note "variable defined here"
+              :help-notes
+              (list
+               (source-error:make-help
+                :location source
+                :replacement (lambda (name)
+                               (concatenate 'string "_" name))
+                :message "prefix the variable with '_' to declare it unused")))))))

--- a/src/entry.lisp
+++ b/src/entry.lisp
@@ -198,9 +198,7 @@
   (declare (type string filename))
 
   (with-open-file (file-stream filename :if-does-not-exist :error)
-    (let ((coalton-file (error:make-coalton-file
-                         :stream file-stream
-                         :name filename)))
+    (let ((coalton-file (error:make-coalton-file filename)))
       (multiple-value-bind (code env)
           (entry-point (parser:read-program file-stream coalton-file :mode :file))
 

--- a/src/entry.lisp
+++ b/src/entry.lisp
@@ -27,8 +27,6 @@
 
          (program (parser:rename-variables program))
 
-         (file (parser:program-file program))
-
          (env *global-environment*)
 
          (tc:*env-update-log* nil))
@@ -36,30 +34,26 @@
     (multiple-value-bind (type-definitions instances env)
         (tc:toplevel-define-type (parser:program-types program)
                                  (parser:program-structs program)
-                                 file
                                  env)
 
       (multiple-value-bind (class-definitions env)
           (tc:toplevel-define-class (parser:program-classes program)
-                                    file
                                     env)
 
         (multiple-value-bind (ty-instances env)
-            (tc:toplevel-define-instance (append instances (parser:program-instances program)) env file)
+            (tc:toplevel-define-instance (append instances (parser:program-instances program)) env)
 
           (multiple-value-bind (toplevel-definitions env)
               (tc:toplevel-define (parser:program-defines program)
                                   (parser:program-declares program)
-                                  file
                                   env)
 
             (multiple-value-bind (toplevel-instances)
                 (tc:toplevel-typecheck-instance ty-instances
                                                 (append instances (parser:program-instances program))
-                                                env
-                                                file)
+                                                env)
 
-              (setf env (tc:toplevel-specialize (parser:program-specializations program) env file))
+              (setf env (tc:toplevel-specialize (parser:program-specializations program) env))
 
               (let ((monomorphize-table (make-hash-table :test #'eq))
 
@@ -83,7 +77,7 @@
                                            monomorphize-table)
                                   t))
 
-                (analysis:analyze-translation-unit translation-unit env file)
+                (analysis:analyze-translation-unit translation-unit env)
 
                 (multiple-value-bind (program env)
                     (codegen:compile-translation-unit translation-unit monomorphize-table env)
@@ -108,9 +102,8 @@
                           ,program))
                    env))))))))))
 
-(defun expression-entry-point (node file)
-  (declare (type parser:node node)
-           (type error:coalton-file file))
+(defun expression-entry-point (node)
+  (declare (type parser:node node))
 
   (let ((env *global-environment*))
 
@@ -118,8 +111,7 @@
         (tc:infer-expression-type (parser:rename-variables node)
                                   (tc:make-variable)
                                   nil
-                                  (tc:make-tc-env :env env)
-                                  file)
+                                  (tc:make-tc-env :env env))
 
       (multiple-value-bind (preds subs)
           (tc:solve-fundeps env preds subs)
@@ -127,16 +119,15 @@
         (setf accessors (tc:apply-substitution subs accessors))
 
         (multiple-value-bind (accessors subs_)
-            (tc:solve-accessors accessors file env)
+            (tc:solve-accessors accessors env)
           (setf subs (tc:compose-substitution-lists subs subs_))
 
           (when accessors
             (error 'tc:tc-error
-                   :err (tc:coalton-error
-                         :span (tc:accessor-source (first accessors))
-                         :file file
-                         :message "Ambiguous accessor"
-                         :primary-note "accessor is ambiguous")))
+                   :location (tc:accessor-source (first accessors))
+                   
+                   :message "Ambiguous accessor"
+                   :primary-note "accessor is ambiguous"))
 
           (let* ((preds (tc:reduce-context env preds subs))
                  (subs (tc:compose-substitution-lists
@@ -171,44 +162,24 @@
                                (tc:ty-scheme-type scheme))))
 
               (error 'tc:tc-error
-                     :err (error:coalton-error
-                           :span (tc:node-source node)
-                           :file file
-                           :message "Unable to codegen"
-                           :primary-note (format nil
-                                                 "expression has type ~A~{ ~S~}.~{ (~S)~} => ~S with unresolved constraint~A ~S"
-                                                 (if settings:*coalton-print-unicode*
-                                                     "∀"
-                                                     "FORALL")
-                                                 tvars
-                                                 (tc:qualified-ty-predicates qual-type)
-                                                 (tc:qualified-ty-type qual-type)
-                                                 (if (= (length (tc:qualified-ty-predicates qual-type)) 1)
-                                                     ""
-                                                     "s")
-                                                 (tc:qualified-ty-predicates qual-type))
-                           :notes
-                           (list
-                            (error:make-coalton-error-note
-                             :type :secondary
-                             :span (tc:node-source node)
-                             :message "Add a type assertion with THE to resolve ambiguity")))))))))))
-
-(defun file-entry-point (filename)
-  (declare (type string filename))
-
-  (with-open-file (file-stream filename :if-does-not-exist :error)
-    (let ((coalton-file (error:make-coalton-file filename)))
-      (multiple-value-bind (code env)
-          (entry-point (parser:read-program file-stream coalton-file :mode :file))
-
-        (setf *global-environment* env)
-
-        code))))
-
-(defun debug-file-entry-point (filename)
-  (declare (type string filename))
-
-  (let ((settings:*coalton-skip-update* t)
-        (settings:*emit-type-annotations* nil))
-    (file-entry-point filename)))
+                     :location (tc:node-source node)
+                     
+                     :message "Unable to codegen"
+                     :primary-note (format nil
+                                           "expression has type ~A~{ ~S~}.~{ (~S)~} => ~S with unresolved constraint~A ~S"
+                                           (if settings:*coalton-print-unicode*
+                                               "∀"
+                                               "FORALL")
+                                           tvars
+                                           (tc:qualified-ty-predicates qual-type)
+                                           (tc:qualified-ty-type qual-type)
+                                           (if (= (length (tc:qualified-ty-predicates qual-type)) 1)
+                                               ""
+                                               "s")
+                                           (tc:qualified-ty-predicates qual-type))
+                     :notes
+                     (list
+                      (source-error:make-note
+                       :type :secondary
+                       :location (tc:node-source node)
+                       :message "Add a type assertion with THE to resolve ambiguity"))))))))))

--- a/src/error.lisp
+++ b/src/error.lisp
@@ -1,24 +1,20 @@
 (defpackage #:coalton-impl/error
   (:use #:cl)
-  (:local-nicknames
-   (#:util #:coalton-impl/util))
   (:export
    #:coalton-internal-condition         ; CONDITION
    #:coalton-base-error                 ; CONDITION
-   #:coalton-error-err                  ; ACCESSOR
-   #:coalton-error-text                 ; ACCESSOR
    #:coalton-base-warning               ; CONDITION
    #:coalton-warning-err                ; ACCESSOR
-   #:render-coalton-error               ; FUNCTION
-   #:render-coalton-warning             ; FUNCTION
    #:coalton-internal-type-error        ; CONDITION
    #:coalton-file                       ; TYPE
-   #:coalton-file-stream                ; ACCESSOR
    #:coalton-file-name                  ; ACCESSOR
-   #:make-coalton-file                  ; FUNCTION
+   #:deferred-note                      ; MACRO
    #:make-coalton-error-note            ; FUNCTION
    #:make-coalton-error-help            ; FUNCTION
    #:make-coalton-error-context         ; FUNCTION
+   #:make-coalton-file                  ; FUNCTION
+   #:make-coalton-ide-file              ; FUNCTION
+   #:make-coalton-string                ; FUNCTION
    #:*coalton-error-context*            ; VARIABLE
    #:coalton-error                      ; MACRO
    #:coalton-error-location             ; ACCESSOR
@@ -36,521 +32,89 @@
              (declare (ignore c))
              (format s "Unhandled internal condition.~%~%If you are seeing this, please file an issue on Github."))))
 
-(define-condition coalton-base-error (error)
-  ((err :accessor coalton-error-err
-        :initarg :err
-        :type (or null function))
-   (text :accessor coalton-error-text
-         :initarg :text
-         :initform nil
-         :type (or null string)))
-  (:documentation "The base type for user-facing errors. Only ERR needs to be specified, and TEXT will be filled when RENDER-COALTON-ERROR is called.")
-  (:report (lambda (c s)
-             (if (coalton-error-text c)
-                 (write-string (coalton-error-text c) s)
-                 (display-coalton-error s (coalton-error-err c))))))
-
-(define-condition coalton-base-warning (style-warning)
-  ((err :accessor coalton-warning-err
-        :initarg :err
-        :type (or null function))
-   (text :accessor coalton-warning-text
-         :initarg :text
-         :initform nil
-         :type (or null string)))
-    (:documentation "The base type for user-facing warnings. Only ERR needs to be specified, and TEXT will be filled when RENDER-COALTON-WARNING is called.")
-    (:report (lambda (c s)
-             (if (coalton-warning-text c)
-                 (write-string (coalton-warning-text c) s)
-                 (display-coalton-error s (coalton-warning-err c))))))
-
-(defun render-coalton-error (e)
-  "Render the error object within a COALTON-BASE-ERROR to text, removing the need to keep source file handles open."
-  (declare (type coalton-base-error e))
-  (let ((*print-escape* nil))
-    (setf (coalton-error-text e)
-          (with-output-to-string (s)
-            (print-object e s))
-          (coalton-error-err e)
-          nil)))
-
-(defun render-coalton-warning (w)
-  "Render the error object within a COALTON-BASE-ERROR to text, removing the need to keep source file handles open."
-  (declare (type coalton-base-warning w))
-  (let ((*print-escape* nil))
-    (setf (coalton-warning-text w)
-          (with-output-to-string (s)
-            (print-object w s))
-          (coalton-warning-err w)
-          nil)))
-
-
 (define-condition coalton-internal-type-error (coalton-internal-condition)
   ())
 
-;;;
-;;; Error Rendering
-;;;
+(define-condition coalton-base-error (source-error:source-error)
+  ())
 
-(defstruct (coalton-error-note
-            (:copier nil))
-  (type    (util:required 'type)    :type (member :primary :secondary) :read-only t)
-  (span    (util:required 'span)    :type (cons integer integer)       :read-only t)
-  (message (util:required 'message) :type string                       :read-only t))
+(define-condition coalton-base-warning (source-error:source-warning)
+  ())
 
-(defun coalton-error-note-list-p (x)
-  (and (alexandria:proper-list-p x)
-       (every #'coalton-error-note-p x)))
+;; Support direct compilation of files and strings, and slime's method
+;; of writing out a tempfile containing a form taken from within an
+;; original source file.
 
-(deftype coalton-error-note-list ()
-  '(satisfies coalton-error-note-list-p))
+(defclass coalton-file () ())
 
+(defclass coalton-source-file (coalton-file)
+  ((source-filename :initarg :source-filename
+                    :reader source-filename
+                    :documentation "The file containing source to be compiled.")
+   (original-filename :initarg :original-filename
+                      :reader original-filename
+                      :initform nil
+                      :reader coalton-file-name
+                      :documentation "The original name of the source file, if source was copied iinto place for compilation.")
+   (original-position :initarg :original-position
+                      :initform 0)))
 
-(defstruct (coalton-error-help
-            (:copier nil))
-  (span        (util:required 'span)        :type (cons integer integer)     :read-only t)
-  (replacement (util:required 'replacement) :type (function (string) string) :read-only t)
-  (message     (util:required 'message)     :type string                     :read-only t))
+(defun make-coalton-file (filename)
+  (make-instance 'coalton-source-file
+    :source-filename filename
+    :original-filename filename))
 
-(defun coalton-error-help-list-p (x)
-  (and (alexandria:proper-list-p x)
-       (every #'coalton-error-help-p x)))
+(defun make-coalton-ide-file (source-filename original-filename original-position)
+  (make-instance 'coalton-source-file
+    :source-filename source-filename
+    :original-filename original-filename
+    :original-position original-position))
 
-(deftype coalton-error-help-list ()
-  '(satisfies coalton-error-help-list-p))
+(defmethod source-error:source-name ((object coalton-source-file))
+  (or (original-filename object)
+      (source-filename object)))
 
+(defmethod source-error:source-stream ((object coalton-source-file))
+  (open (source-filename object)))
 
-(defstruct (coalton-error-context
-            (:copier nil))
-  (message (util:required 'message) :type string :read-only t))
+(defclass coalton-source-string (coalton-file)
+  ((source-string :initarg :source-string
+                  :reader source-string)))
+
+(defmethod coalton-file-name ((object coalton-source-string))
+  "string")
+
+(defun make-coalton-string (string)
+  (make-instance 'coalton-source-string :source-string string))
+
+(defmethod source-error:source-name ((object coalton-source-string))
+  "string input")
+
+(defmethod source-error:source-stream ((object coalton-source-string))
+  (make-string-input-stream (source-string object)))
 
 (defvar *coalton-error-context* nil)
 
-(defstruct (coalton-file
-            (:copier nil))
-  (stream (util:required 'stream) :type stream :read-only t)
-  (name   (util:required 'name)   :type string :read-only t))
+(defun coalton-error (&key (type :error) span highlight file message primary-note notes help-notes)
+  (source-error:source-error :type type
+                             :location (if (eql :end highlight)
+                                           (cdr span)
+                                           span)
+                             :source file
+                             :message message
+                             :primary-note primary-note
+                             :notes notes
+                             :help help-notes
+                             :context *coalton-error-context*))
 
-(defstruct (coalton-error
-            (:copier nil))
-  (type            (util:required 'type)     :type (member :error :warn)   :read-only t)
-  (file            (util:required 'file)     :type coalton-file            :read-only t)
-  (location        (util:required 'location) :type integer                 :read-only t)
-  (message         (util:required 'message)  :type string                  :read-only t)
-  (notes           (util:required 'notes)    :type coalton-error-note-list :read-only t)
-  (help-notes      nil                       :type coalton-error-help-list :read-only t)
-  (context         *coalton-error-context*   :type list                    :read-only t))
+(defun make-coalton-error-help (&key span replacement message)
+  (source-error:help :span span :replacement replacement :message message))
 
-(defmacro coalton-error (&key (type :error) span file (highlight :all) message primary-note notes help-notes)
-  `(lambda ()
-     (coalton-error_
-      :type ,type
-      :span ,span
-      :file ,file
-      :highlight ,highlight
-      :message ,message
-      :primary-note ,primary-note
-      :notes ,notes
-      :help-notes ,help-notes)))
+(defun make-coalton-error-note (&key type span message)
+  (source-error:note :type type :span span :message message))
 
-(defun coalton-error_ (&key
-                         (type :error)
-                         span
-                         file
-                         (highlight :all)
-                         message
-                         primary-note
-                         notes
-                         help-notes)
-  "Construct a COALTON-ERROR with a message and primary note attached to the provided form.
+(defun make-coalton-error-context (&key message)
+  (source-error:context :message message))
 
-MESSAGE and PRIMARY-NOTE must be supplied string arguments.
-NOTES and HELP-NOTES may optionally be supplied notes and help messages."
-  (declare (type cons span)
-           (type coalton-file file)
-           (type (member :all :end) highlight)
-           (type string message primary-note)
-           (type list notes help-notes)
-           (values coalton-error &optional))
-
-  (let ((start (car span))
-        (end (cdr span)))
-    (make-coalton-error
-     :type type
-     :file file
-     :location (ecase highlight
-                 (:all (car span))
-                 (:end (cdr span)))
-     :message message
-     :notes (list*
-             (ecase highlight
-               (:all
-                (make-coalton-error-note
-                 :type :primary
-                 :span (cons start end)
-                 :message primary-note))
-               (:end
-                (make-coalton-error-note
-                 :type :primary
-                 :span (cons (1- end) end)
-                 :message primary-note)))
-             notes)
-     :help-notes help-notes)))
-
-(defstruct (coalton-error-resolved-note
-            (:copier nil))
-  "A COALTON-ERROR-NOTE with its location resolved in the file's context."
-  (type         (util:required 'type)         :type (member :primary :secondary) :read-only t)
-  (start-line   (util:required 'start-line)   :type integer                      :read-only t)
-  (start-column (util:required 'start-column) :type integer                      :read-only t)
-  (end-line     (util:required 'end-line)     :type integer                      :read-only t)
-  (end-column   (util:required 'end-column)   :type integer                      :read-only t)
-  (message      (util:required 'message)      :type string                       :read-only t))
-
-(defun display-coalton-error (stream error)
-  (declare (type stream stream)
-           (type function error))
-
-  (let* ((*print-circle* nil)
-
-         (error (funcall error))
-
-         (file-stream (coalton-file-stream (coalton-error-file error)))
-         (file-stream-pos (file-position file-stream)))
-
-    (progn
-
-      ;; Print the error message and location
-      (multiple-value-bind (line-number line-start-index)
-          (get-line-from-index file-stream (coalton-error-location error))
-        (format stream
-                "~(~A~): ~A~%  --> ~A:~D:~D~%"
-                (coalton-error-type error)
-                (coalton-error-message error)
-                (coalton-file-name (coalton-error-file error))
-                line-number
-                (- (coalton-error-location error) line-start-index)))
-
-      ;; Print the error notes
-      (let* (;; We need to keep track of the current depth of multiline
-             ;; notes so that we can pad the left with the correct
-             ;; number of columns.
-             (multiline-note-stack nil)
-             (multiline-note-current-depth 0)
-             (multiline-note-max-depth 0)
-
-             ;; Sort notes by start of span
-             (sorted-notes
-               (stable-sort
-                (coalton-error-notes error)
-                #'<
-                :key (lambda (note)
-                       (car (coalton-error-note-span note)))))
-
-             ;; Attach line info to notes and figure out the maximum
-             ;; multiline note depth we will need.
-             (resolved-notes
-               (mapcar
-                (lambda (note)
-                  (let ((start (car (coalton-error-note-span note)))
-                        (end (cdr (coalton-error-note-span note))))
-                    ;; Get line info for the start of the span
-                    (multiple-value-bind (start-line start-line-start)
-                        (get-line-from-index file-stream start)
-
-                      ;; Get line info for the end of the span
-                      (multiple-value-bind (end-line end-line-start)
-                          (get-line-from-index file-stream (1- end))
-
-                        ;; Compute column numbers
-                        (let ((start-column (- start start-line-start))
-                              (end-column   (- end end-line-start)))
-
-                          ;; Ensure that spans are valid
-                          (when (or (< end-line start-line)
-                                    (and (= end-line start-line)
-                                         (< end-column start-column)))
-                            (util:coalton-bug "Error note contains invalid span ~A:~A to ~A:~A"
-                                              start-line start-column end-line end-column))
-
-                          ;; Clear any multiline notes in the stack that we have now passed.
-                          (loop :while (and (car multiline-note-stack)
-                                            (> start-line
-                                               (coalton-error-resolved-note-end-line
-                                                (car multiline-note-stack))))
-                                :do (pop multiline-note-stack)
-                                    (decf multiline-note-current-depth))
-
-                          (let ((resolved-note (make-coalton-error-resolved-note
-                                                :type (coalton-error-note-type note)
-                                                :start-line start-line
-                                                :start-column start-column
-                                                :end-line end-line
-                                                :end-column end-column
-                                                :message (coalton-error-note-message note))))
-
-                            ;; If this is a multiline note then keep track of the current depth.
-                            (when (/= end-line start-line)
-                              (push resolved-note multiline-note-stack)
-                              (incf multiline-note-current-depth)
-
-                              (if (> multiline-note-current-depth
-                                     multiline-note-max-depth)
-                                  (setf multiline-note-max-depth
-                                        multiline-note-current-depth)))
-
-                            resolved-note))))))
-                sorted-notes))
-
-             ;; Get the character width of the last line mentioned.
-             (first-line (coalton-error-resolved-note-start-line (car resolved-notes)))
-             (last-line (reduce #'max resolved-notes :key #'coalton-error-resolved-note-end-line))
-             (line-number-width
-               (1+ (floor (log last-line 10)))))
-
-        ;; Ensure the multiline stack is empty so we can reuse it when printing notes.
-        (setf multiline-note-stack nil
-              multiline-note-current-depth 0)
-
-        ;; Print first empty line.
-        (format stream
-                " ~v{~C~:*~} |~%"
-                line-number-width
-                '(#\Space))
-
-        (let (;; Keep track of which lines we have output.  We start at
-              ;; one line before the beginning to ensure the first line
-              ;; is printed correctly.
-              (current-line (1- first-line)))
-          (labels ((print-line-number (line-number show-line-number)
-                     (format stream
-                             " ~:[~vA~*~*~;~*~*~v{~C~:*~}~] | ~{~:[ ~;|~]~}"
-                             (not show-line-number)
-                             line-number-width
-                             line-number
-                             line-number-width
-                             '(#\Space)
-                             (mapcar
-                              (lambda (note)
-                                (>= (coalton-error-resolved-note-end-line note)
-                                    line-number))
-                              multiline-note-stack)))
-
-                   (print-line-contents (line-number)
-                     (print-line-number line-number t)
-                     (format stream " ~v@{ ~}~A~%"
-                             (- multiline-note-max-depth
-                                multiline-note-current-depth)
-                             (get-nth-line file-stream line-number)))
-
-                   (note-highlight-char (note)
-                     (ecase (coalton-error-resolved-note-type note)
-                       (:primary #\^)
-                       (:secondary #\-)))
-
-                   (print-singleline-note (note)
-                     (print-line-number (coalton-error-resolved-note-start-line note) nil)
-                     (format stream
-                             " ~v{~C~:*~}~v{~C~:*~} ~A~%"
-                             (+ (coalton-error-resolved-note-start-column note)
-                                (- multiline-note-max-depth
-                                   multiline-note-current-depth))
-                             '(#\Space)
-                             (- (coalton-error-resolved-note-end-column note)
-                                (coalton-error-resolved-note-start-column note))
-                             (list (note-highlight-char note))
-                             (coalton-error-resolved-note-message note)))
-
-                   (print-multiline-note-start (note)
-                     (print-line-number (coalton-error-resolved-note-start-line note) nil)
-                     (format stream " ~v{~C~:*~}~C~%"
-                             (+ (coalton-error-resolved-note-start-column note)
-                                (- multiline-note-max-depth
-                                   multiline-note-current-depth))
-                             '(#\_)
-                             (note-highlight-char note)))
-
-                   (print-multiline-note-end (note)
-                     (print-line-number (coalton-error-resolved-note-start-line note) nil)
-                     (format stream
-                             "~v{~C~:*~}~C ~A~%"
-                             (+ (coalton-error-resolved-note-end-column note)
-                                (- multiline-note-max-depth
-                                   multiline-note-current-depth))
-                             '(#\_)
-                             (note-highlight-char note)
-                             (coalton-error-resolved-note-message note)))
-
-                   (print-finished-multiline-notes-for-line (line-number)
-                     ;; Check if there are any multiline notes that need to be printed
-                     (loop :for stack-head := multiline-note-stack :then (cdr stack-head)
-                           :for note := (car stack-head)
-
-                           :when (null stack-head)
-                             :do (return)
-
-                           :when (= line-number (coalton-error-resolved-note-end-line note))
-                             :do (print-multiline-note-end note)
-
-                           :when (and (eq note (car multiline-note-stack))
-                                      (>= line-number (coalton-error-resolved-note-end-line note)))
-                             :do (pop multiline-note-stack)
-                                 (decf multiline-note-current-depth)))
-
-                   (print-lines-until (line-number)
-                     (cond (;; If we are on the same line then
-                            ;; don't reprint.
-                            (= line-number current-line))
-
-                           (;; If we are within 3 lines of the
-                            ;; previous one then just print those
-                            ;; lines.
-                            (>= 3 (- line-number current-line))
-                            (loop :for line :from current-line :below line-number
-                                  :do (print-line-contents (1+ line))
-                                  :unless (= (1+ line) line-number)
-                                    :do (print-finished-multiline-notes-for-line (1+ line))))
-
-                           (;; Otherwise split the output.
-                            t
-                            (print-line-contents (1+ current-line))
-
-                            ;; Print out any intermediate multiline note endings.
-                            (loop :for note :in multiline-note-stack
-                                  :when (< current-line (coalton-error-resolved-note-end-line note) line-number)
-                                    :do (print-lines-until (coalton-error-resolved-note-end-line note)))
-
-                            (format stream " ...~%")
-                            (print-line-contents (1- line-number))
-                            (print-line-contents line-number)))
-                     (setf current-line line-number)))
-
-            ;; Walk down our notes, printing lines and notes as needed
-            ;; and keeping track of multiline note depth.
-            (loop :for note :in resolved-notes
-                  :do (cond
-                        ;; For multiline we need to add to the current stack.
-                        ((/= (coalton-error-resolved-note-start-line note)
-                             (coalton-error-resolved-note-end-line note))
-                         ;; Print lines until this note.
-                         (print-lines-until (coalton-error-resolved-note-start-line note))
-
-                         ;; Print out a new row with underlines connecting
-                         ;; back to the multiline position.
-                         (print-multiline-note-start note)
-
-                         ;; Push this note on to the stack for safe keeping.
-                         (push note multiline-note-stack)
-                         (incf multiline-note-current-depth))
-                        ;; For non-multiline just print the note
-                        (t
-                         ;; Print lines until this note.
-                         (print-lines-until (coalton-error-resolved-note-start-line note))
-
-                         (print-singleline-note note)
-
-                         (print-finished-multiline-notes-for-line (coalton-error-resolved-note-start-line note)))))
-
-            ;; If there are any multline notes that have not closed out then
-            ;; print them.
-            (print-lines-until last-line)
-            (print-finished-multiline-notes-for-line last-line))))
-
-      ;; Print help messages
-      (loop :for help :in (coalton-error-help-notes error)
-            :for start := (car (coalton-error-help-span help))
-            :for end := (cdr (coalton-error-help-span help))
-            :do (multiple-value-bind (start-line start-line-start)
-                    (get-line-from-index file-stream start)
-                  (multiple-value-bind (end-line end-line-start)
-                      (get-line-from-index file-stream (1- end))
-
-                    (unless (= start-line end-line)
-                      (util:coalton-bug "multiline help messages not supported yet."))
-
-                    (let ((line-number-width (1+ (floor (log end-line 10)))))
-                      (format stream "help: ~A~%"
-                              (coalton-error-help-message help))
-
-                      (format stream " ~vD | ~A"
-                              line-number-width
-                              start-line
-                              (subseq (get-nth-line file-stream start-line)
-                                      0 (- start start-line-start)))
-
-                      (let ((replaced-text (funcall (coalton-error-help-replacement help)
-                                                    (subseq (get-nth-line file-stream start-line)
-                                                            (- start start-line-start)
-                                                            (- end end-line-start)))))
-                        (format stream "~A~A~%"
-                                replaced-text
-                                (subseq (get-nth-line file-stream start-line)
-                                        (- end end-line-start)))
-
-                        (format stream
-                                " ~v{~C~:*~} |~v{~C~:*~}~v{~C~:*~}~%"
-                                line-number-width
-                                '(#\Space)
-                                (1+ (- start start-line-start))
-                                '(#\Space)
-                                (length replaced-text)
-                                '(#\-)))))))
-
-      ;; Print error context
-      (loop :for context :in (coalton-error-context error)
-            :do (format stream "note: ~A~%" (coalton-error-context-message context)))
-
-      ;; Reset our file position to avoid messing things up.
-      (file-position file-stream file-stream-pos))))
-
-(defun get-line-from-index (file index)
-  "Get the line number corresponding to the character offset INDEX.
-
-Returns (VALUES LINE-NUM LINE-START-INDEX)"
-  (declare (type stream file)
-           (type integer index)
-           (values integer integer))
-  (file-position file 0)
-  (let ((line 1)
-        (line-start-index 0))
-    (loop :for char := (read-char file)
-          :for code := (char-code char)
-          ;; It is assumed that code is utf-8 code point.
-          :for length := (cond ((<= code #x7f) 1)
-                               ((<= code #x7ff) 2)
-                               ((<= code #xffff) 3)
-                               (t 4))
-          :for i := 0 :then (+ i length)
-          :when (char= char #\Newline)
-            :do (setf line (1+ line)
-                      line-start-index (1+ i))
-          :when (>= i index)
-            :return nil)
-    (values line line-start-index)))
-
-(defun get-source-line-info (file form)
-  "Get source information about FORM which can be used in errors.
-
-Returns (VALUES LINE-NUM LINE-START-INDEX LINE-END-INDEX)"
-  (declare (type stream file)
-           (type cst:cst form))
-  (let ((start-index (car (cst:source form)))
-        (end-index   (cdr (cst:source form))))
-    (multiple-value-bind (line-number line-start-index)
-        (get-line-from-index file start-index)
-      (values line-number
-              (- start-index line-start-index)
-              (- end-index   line-start-index)))))
-
-(defun get-nth-line (file index)
-  "Get the INDEXth line FILE. This function uses 1 based indexing."
-  (declare (type stream file)
-           (type integer index)
-           (values string &optional))
-  (file-position file 0)
-  (loop :for i :from 1 :to index
-        :for line := (read-line file)
-        :when (= i index)
-          :do (return-from get-nth-line line))
-
-  (util:coalton-bug "Line number ~D out of bounds for file ~A" index file))
+(defmacro deferred-note (&rest args)
+  (source-error:deferred-note `(lambda () (note ,@args))))

--- a/src/error.lisp
+++ b/src/error.lisp
@@ -1,120 +1,27 @@
 (defpackage #:coalton-impl/error
-  (:use #:cl)
+  (:use
+   #:cl)
   (:export
-   #:coalton-internal-condition         ; CONDITION
-   #:coalton-base-error                 ; CONDITION
-   #:coalton-base-warning               ; CONDITION
-   #:coalton-warning-err                ; ACCESSOR
-   #:coalton-internal-type-error        ; CONDITION
-   #:coalton-file                       ; TYPE
-   #:coalton-file-name                  ; ACCESSOR
-   #:deferred-note                      ; MACRO
-   #:make-coalton-error-note            ; FUNCTION
-   #:make-coalton-error-help            ; FUNCTION
-   #:make-coalton-error-context         ; FUNCTION
-   #:make-coalton-file                  ; FUNCTION
-   #:make-coalton-ide-file              ; FUNCTION
-   #:make-coalton-string                ; FUNCTION
-   #:*coalton-error-context*            ; VARIABLE
-   #:coalton-error                      ; MACRO
-   #:coalton-error-location             ; ACCESSOR
-   #:coalton-error-file                 ; ACCESSOR
-   #:display-coalton-error              ; FUNCTION
-   ))
+   #:coalton-internal-condition
+   #:coalton-error
+   #:coalton-warning
+   #:coalton-internal-type-error))
 
 (in-package #:coalton-impl/error)
-
 
 (define-condition coalton-internal-condition (error)
   ()
   (:documentation "An internal Coalton condition for use in signaling. Internal conditions should always be caught.")
-  (:report (lambda (c s)
-             (declare (ignore c))
-             (format s "Unhandled internal condition.~%~%If you are seeing this, please file an issue on Github."))))
+  (:report
+   (lambda (c s)
+     (declare (ignore c))
+     (format s "Unhandled internal condition.~%~%If you are seeing this, please file an issue on Github."))))
 
 (define-condition coalton-internal-type-error (coalton-internal-condition)
   ())
 
-(define-condition coalton-base-error (source-error:source-error)
+(define-condition coalton-error (source-error:source-error)
   ())
 
-(define-condition coalton-base-warning (source-error:source-warning)
+(define-condition coalton-warning (source-error:source-warning)
   ())
-
-;; Support direct compilation of files and strings, and slime's method
-;; of writing out a tempfile containing a form taken from within an
-;; original source file.
-
-(defclass coalton-file () ())
-
-(defclass coalton-source-file (coalton-file)
-  ((source-filename :initarg :source-filename
-                    :reader source-filename
-                    :documentation "The file containing source to be compiled.")
-   (original-filename :initarg :original-filename
-                      :reader original-filename
-                      :initform nil
-                      :reader coalton-file-name
-                      :documentation "The original name of the source file, if source was copied iinto place for compilation.")
-   (original-position :initarg :original-position
-                      :initform 0)))
-
-(defun make-coalton-file (filename)
-  (make-instance 'coalton-source-file
-    :source-filename filename
-    :original-filename filename))
-
-(defun make-coalton-ide-file (source-filename original-filename original-position)
-  (make-instance 'coalton-source-file
-    :source-filename source-filename
-    :original-filename original-filename
-    :original-position original-position))
-
-(defmethod source-error:source-name ((object coalton-source-file))
-  (or (original-filename object)
-      (source-filename object)))
-
-(defmethod source-error:source-stream ((object coalton-source-file))
-  (open (source-filename object)))
-
-(defclass coalton-source-string (coalton-file)
-  ((source-string :initarg :source-string
-                  :reader source-string)))
-
-(defmethod coalton-file-name ((object coalton-source-string))
-  "string")
-
-(defun make-coalton-string (string)
-  (make-instance 'coalton-source-string :source-string string))
-
-(defmethod source-error:source-name ((object coalton-source-string))
-  "string input")
-
-(defmethod source-error:source-stream ((object coalton-source-string))
-  (make-string-input-stream (source-string object)))
-
-(defvar *coalton-error-context* nil)
-
-(defun coalton-error (&key (type :error) span highlight file message primary-note notes help-notes)
-  (source-error:source-error :type type
-                             :location (if (eql :end highlight)
-                                           (cdr span)
-                                           span)
-                             :source file
-                             :message message
-                             :primary-note primary-note
-                             :notes notes
-                             :help help-notes
-                             :context *coalton-error-context*))
-
-(defun make-coalton-error-help (&key span replacement message)
-  (source-error:help :span span :replacement replacement :message message))
-
-(defun make-coalton-error-note (&key type span message)
-  (source-error:note :type type :span span :message message))
-
-(defun make-coalton-error-context (&key message)
-  (source-error:context :message message))
-
-(defmacro deferred-note (&rest args)
-  (source-error:deferred-note `(lambda () (note ,@args))))

--- a/src/parser/base.lisp
+++ b/src/parser/base.lisp
@@ -22,7 +22,6 @@
    #:identifier-src-source              ; ACCESSOR
    #:identifier-src-list                ; TYPE
    #:parse-error                        ; CONDITION
-   #:parse-error-err                    ; ACCESSOR
    #:parse-list                         ; FUNCTION
    ))
 
@@ -69,15 +68,14 @@
 (deftype identifier-src-list ()
   '(satisfies identifier-src-list-p))
 
-(define-condition parse-error (error:coalton-base-error)
+(define-condition parse-error (error:coalton-error)
   ())
 
-(defun parse-list (f list_ file)
+(defun parse-list (f list_)
   (declare (type function f)
            (type cst:cst list_)
-           (type error:coalton-file file)
            (values list))
 
   (loop :for list := list_ :then (cst:rest list)
         :while (cst:consp list)
-        :collect (funcall f (cst:first list) file)))
+        :collect (funcall f (cst:first list))))

--- a/src/parser/toplevel.lisp
+++ b/src/parser/toplevel.lisp
@@ -415,7 +415,7 @@
 (defstruct (program
             (:copier nil))
   (package         (util:required 'package)         :type package                       :read-only t)
-  (file            (util:required 'file)            :type coalton-file                  :read-only t)
+  (file            (util:required 'file)            :type source-error:source           :read-only t)
   (types           (util:required 'types)           :type toplevel-define-type-list     :read-only nil)
   (structs         (util:required 'structs)         :type toplevel-define-struct-list   :read-only nil)
   (declares        (util:required 'declares)        :type toplevel-declare-list         :read-only nil)
@@ -430,10 +430,9 @@
 (defpackage #:coalton-impl/parser/read
   (:use))
 
-(defun read-program (stream file &key (mode (error "you must supply this bozo!")))
+(defun read-program (stream &key (mode (error "you must supply this bozo!")))
   "Read a PROGRAM from the COALTON-FILE."
-  (declare (type coalton-file file)
-           (type (member :file :toplevel-macro :test) mode)
+  (declare (type (member :file :toplevel-macro :test) mode)
            (values program))
 
   (let* (;; Setup eclector readtable
@@ -453,19 +452,17 @@
 
         (unless presentp
           (error 'parse-error
-                 :err (coalton-error
-                       :span (cons (- (file-position stream) 2)
-                                   (- (file-position stream) 1))
-                       :file file
-                       :message "Unexpected EOF"
-                       :primary-note "missing package form")))
+                 :location (cons (- (file-position stream) 2)
+                                 (- (file-position stream) 1))
+                 :message "Unexpected EOF"
+                 :primary-note "missing package form"))
 
-        (setf *package* (parse-package form file))))
+        (setf *package* (parse-package form))))
 
     ;; imma parsin mah program
     (let* ((program (make-program
                      :package *package*
-                     :file file
+                     :file source-error:*source*
                      :types nil
                      :structs nil
                      :declares nil
@@ -482,28 +479,24 @@
 
           (when (and eofp (eq :toplevel-macro mode))
             (error 'parse-error
-                   :err (coalton-error
-                         :span (cons (- (file-position stream) 2)
-                                     (- (file-position stream) 1))
-                         :file file
-                         :message "Unexpected EOF"
-                         :primary-note "missing close parenthesis")))
+                   :location (cons (- (file-position stream) 2)
+                                   (- (file-position stream) 1))
+                   :message "Unexpected EOF"
+                   :primary-note "missing close parenthesis"))
 
           (unless presentp
             (return))
 
-          (when (and (parse-toplevel-form form program attributes file)
+          (when (and (parse-toplevel-form form program attributes)
                      (plusp (length attributes)))
             (util:coalton-bug "parse-toplevel-form indicated that a form was parsed but did not
 consume all attributes"))))
 
       (unless (zerop (length attributes))
         (error 'parse-error
-               :err (coalton-error
-                     :span (cst:source (cdr (aref attributes 0)))
-                     :file file
-                     :message "Orphan attribute"
-                     :primary-note "attribute must be attached to another form")))
+               :location (cst:source (cdr (aref attributes 0)))
+               :message "Orphan attribute"
+               :primary-note "attribute must be attached to another form"))
 
       (setf (program-types program) (nreverse (program-types program)))
       (setf (program-structs program) (nreverse (program-structs program)))
@@ -514,7 +507,7 @@ consume all attributes"))))
 
       program)))
 
-(defun read-expression (stream file)
+(defun read-expression (stream)
   (let* (;; Setup eclector readtable
          (eclector.readtable:*readtable*
            (eclector.readtable:copy-readtable eclector.readtable:*readtable*))
@@ -528,12 +521,10 @@ consume all attributes"))))
 
       (unless presentp
         (error 'parse-error
-               :err (coalton-error
-                     :span (cons (- (file-position stream) 2)
-                                 (- (file-position stream) 1))
-                     :file file
-                     :message "Malformed coalton expression"
-                     :primary-note "missing expression")))
+               :location (cons (- (file-position stream) 2)
+                               (- (file-position stream) 1))
+               :message "Malformed coalton expression"
+               :primary-note "missing expression"))
 
       ;; Ensure there is only one form
       (multiple-value-bind (form presentp)
@@ -541,54 +532,43 @@ consume all attributes"))))
 
         (when presentp
           (error 'parse-error
-                 :err (coalton-error
-                       :span (cst:source form)
-                       :file file
-                       :message "Malformed coalton expression"
-                       :primary-note "unexpected form"))))
+                 :location (cst:source form)
+                 :message "Malformed coalton expression"
+                 :primary-note "unexpected form")))
 
-      (parse-expression form file))))
+      (parse-expression form))))
 
-(defun parse-package (form file)
+(defun parse-package (form)
   "Parses a coalton package declaration in the form of (package {name})"
   (declare (type cst:cst form)
-           (type coalton-file file)
            (values package))
 
   ;; Package declarations must start with "PACKAGE"
   (unless (string= (cst:raw (cst:first form)) "PACKAGE")
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source (cst:first form))
-                 :file file
-                 :message "Malformed package declaration"
-                 :primary-note "package declarations must start with `package`")))
+           :location (cst:source (cst:first form))
+           :message "Malformed package declaration"
+           :primary-note "package declarations must start with `package`"))
 
   ;; Package declarations must have a name
   (unless (cst:consp (cst:rest form))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source (cst:first form))
-                 :file file
-                 :message "Malformed package declaration"
-                 :primary-note "missing package name")))
+           :location (cst:source (cst:first form))
+           :message "Malformed package declaration"
+           :primary-note "missing package name"))
 
   ;; Package declarations cannot contain more than two forms
   (when (cst:consp (cst:rest (cst:rest form)))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source (cst:first (cst:rest (cst:rest form))))
-                 :file file
-                 :message "Malformed package declaration"
-                 :primary-note "unexpected forms")))
+           :location (cst:source (cst:first (cst:rest (cst:rest form))))
+           :message "Malformed package declaration"
+           :primary-note "unexpected forms"))
 
   (unless (identifierp (cst:raw (cst:second form)))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source (cst:second form))
-                 :file file
-                 :message "Malformed package declaration"
-                 :primary-note "package name must be a symbol")))
+           :location (cst:source (cst:second form))
+           :message "Malformed package declaration"
+           :primary-note "package name must be a symbol"))
 
   (let* ((package-name (symbol-name (cst:raw (cst:second form))))
 
@@ -600,29 +580,24 @@ consume all attributes"))))
     package))
 
 
-(defun parse-toplevel-form (form program attributes file)
+(defun parse-toplevel-form (form program attributes)
   (declare (type cst:cst form)
            (type program program)
            (type (vector (cons attribute cst:cst)) attributes)
-           (type coalton-file file)
            (values boolean &optional))
 
   (when (cst:atom form)
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source form)
-                 :file file
-                 :message "Malformed toplevel form"
-                 :primary-note "Unexpected atom")))
+           :location (cst:source form)
+           :message "Malformed toplevel form"
+           :primary-note "Unexpected atom"))
 
   ;; Toplevel forms must begin with an atom
   (when (cst:consp (cst:first form))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source (cst:first form))
-                 :file file
-                 :message "Malformed toplevel form"
-                 :primary-note "unexpected list")))
+           :location (cst:source (cst:first form))
+           :message "Malformed toplevel form"
+           :primary-note "unexpected list"))
 
 
 
@@ -630,7 +605,7 @@ consume all attributes"))))
     ((coalton:monomorphize)
      (vector-push-extend
       (cons
-       (parse-monomorphize form file)
+       (parse-monomorphize form)
        form)
       attributes)
 
@@ -639,14 +614,14 @@ consume all attributes"))))
     ((coalton:repr)
      (vector-push-extend
       (cons
-       (parse-repr form file)
+       (parse-repr form)
        form)
       attributes)
 
      nil)
 
     ((coalton:define)
-     (let ((define (parse-define form file))
+     (let ((define (parse-define form))
 
            monomorphize
            monomorphize-form)
@@ -654,36 +629,32 @@ consume all attributes"))))
              :do (etypecase attribute
                    (attribute-repr
                     (error 'parse-error
-                           :err (coalton-error
-                                 :span (cst:source attribute-form)
-                                 :file file
-                                 :message "Invalid target for repr attribute"
-                                 :primary-note "repr must be attached to a define-type"
-                                 :notes
-                                 (list
-                                  (make-coalton-error-note
-                                   :type :secondary
-                                   :span (node-source (toplevel-define-name define))
-                                   :message "when parsing define")))))
+                           :location (cst:source attribute-form)
+                           :message "Invalid target for repr attribute"
+                           :primary-note "repr must be attached to a define-type"
+                           :notes
+                           (list
+                            (source-error:make-note
+                             :type :secondary
+                             :location (node-source (toplevel-define-name define))
+                             :message "when parsing define"))))
 
                    (attribute-monomorphize
                     (when monomorphize
                       (error 'parse-error
-                             :err (coalton-error
-                                   :span (cst:source attribute-form)
-                                   :file file
-                                   :message "Duplicate monomorphize attribute"
-                                   :primary-note "monomorphize attribute here"
-                                   :notes
-                                   (list
-                                    (make-coalton-error-note
-                                     :type :secondary
-                                     :span (cst:source monomorphize-form)
-                                     :message "previous attribute here")
-                                    (make-coalton-error-note
-                                     :type :secondary
-                                     :span (node-source (toplevel-define-name define))
-                                     :message "when parsing define")))))
+                             :location (cst:source attribute-form)
+                             :message "Duplicate monomorphize attribute"
+                             :primary-note "monomorphize attribute here"
+                             :notes
+                             (list
+                              (source-error:make-note
+                               :type :secondary
+                               :location (cst:source monomorphize-form)
+                               :message "previous attribute here")
+                              (source-error:make-note
+                               :type :secondary
+                               :location (node-source (toplevel-define-name define))
+                               :message "when parsing define"))))
 
                     (setf monomorphize attribute)
                     (setf monomorphize-form attribute-form))))
@@ -694,7 +665,7 @@ consume all attributes"))))
        t))
 
     ((coalton:declare)
-     (let ((declare (parse-declare form file))
+     (let ((declare (parse-declare form))
 
            monomorphize
            monomorphize-form)
@@ -703,36 +674,32 @@ consume all attributes"))))
              :do (etypecase attribute
                    (attribute-repr
                     (error 'parse-error
-                           :err (coalton-error
-                                 :span (cst:source attribute-form)
-                                 :file file
-                                 :message "Invalid target for repr attribute"
-                                 :primary-note "repr must be attached to a define-type"
-                                 :notes
-                                 (list
-                                  (make-coalton-error-note
-                                   :type :secondary
-                                   :span (cst:source form)
-                                   :message "when parsing declare")))))
+                           :location (cst:source attribute-form)
+                           :message "Invalid target for repr attribute"
+                           :primary-note "repr must be attached to a define-type"
+                           :notes
+                           (list
+                            (source-error:make-note
+                             :type :secondary
+                             :location (cst:source form)
+                             :message "when parsing declare"))))
 
                    (attribute-monomorphize
                     (when monomorphize
                       (error 'parse-error
-                             :err (coalton-error
-                                   :span (cst:source attribute-form)
-                                   :file file
-                                   :message "Duplicate monomorphize attribute"
-                                   :primary-note "monomorphize attribute here"
-                                   :notes
-                                   (list
-                                    (make-coalton-error-note
-                                     :type :secondary
-                                     :span (cst:source monomorphize-form)
-                                     :message "previous attribute here")
-                                    (make-coalton-error-note
-                                     :type :secondary
-                                     :span (cst:source form)
-                                     :message "when parsing declare")))))
+                             :location (cst:source attribute-form)
+                             :message "Duplicate monomorphize attribute"
+                             :primary-note "monomorphize attribute here"
+                             :notes
+                             (list
+                              (source-error:make-note
+                               :type :secondary
+                               :location (cst:source monomorphize-form)
+                               :message "previous attribute here")
+                              (source-error:make-note
+                               :type :secondary
+                               :location (cst:source form)
+                               :message "when parsing declare"))))
 
                     (setf monomorphize attribute)
                     (setf monomorphize-form attribute-form))))
@@ -743,7 +710,7 @@ consume all attributes"))))
        t))
 
     ((coalton:define-type)
-     (let* ((type (parse-define-type form file))
+     (let* ((type (parse-define-type form))
 
             repr
             repr-form)
@@ -753,38 +720,34 @@ consume all attributes"))))
                    (attribute-repr
                     (when repr
                       (error 'parse-error
-                             :err (coalton-error
-                                   :span (cst:source attribute-form)
-                                   :file file
-                                   :message "Duplicate repr atttribute"
-                                   :primary-note "repr attribute here"
-                                   :notes
-                                   (list
-                                    (make-coalton-error-note
-                                     :type :secondary
-                                     :span (cst:source repr-form)
-                                     :message "previous attribute here")
-                                    (make-coalton-error-note
-                                     :type :secondary
-                                     :span (toplevel-define-type-head-src type)
-                                     :message "when parsing define-type")))))
+                             :location (cst:source attribute-form)
+                             :message "Duplicate repr atttribute"
+                             :primary-note "repr attribute here"
+                             :notes
+                             (list
+                              (source-error:make-note
+                               :type :secondary
+                               :location (cst:source repr-form)
+                               :message "previous attribute here")
+                              (source-error:make-note
+                               :type :secondary
+                               :location (toplevel-define-type-head-src type)
+                               :message "when parsing define-type"))))
 
                     (setf repr attribute)
                     (setf repr-form attribute-form))
 
                    (attribute-monomorphize
                     (error 'parse-error
-                           :err (coalton-error
-                                 :span (cst:source attribute-form)
-                                 :file file
-                                 :message "Invalid target for monomorphize attribute"
-                                 :primary-note "monomorphize must be attached to a define or declare form"
-                                 :notes
-                                 (list
-                                  (make-coalton-error-note
-                                   :type :secondary
-                                   :span (toplevel-define-type-head-src type)
-                                   :message "when parsing define-type")))))))
+                           :location (cst:source attribute-form)
+                           :message "Invalid target for monomorphize attribute"
+                           :primary-note "monomorphize must be attached to a define or declare form"
+                           :notes
+                           (list
+                            (source-error:make-note
+                             :type :secondary
+                             :location (toplevel-define-type-head-src type)
+                             :message "when parsing define-type"))))))
 
        (setf (fill-pointer attributes) 0)
        (setf (toplevel-define-type-repr type) repr)
@@ -793,7 +756,7 @@ consume all attributes"))))
 
     ((coalton:define-struct)
 
-     (let ((struct (parse-define-struct form file))
+     (let ((struct (parse-define-struct form))
            repr
            repr-form)
 
@@ -802,52 +765,46 @@ consume all attributes"))))
                    (attribute-repr
                     (when repr
                       (error 'parse-error
-                             :err (coalton-error
-                                   :span (cst:source attribute-form)
-                                   :file file
-                                   :message "Duplicate repr attribute"
-                                   :primary-note "repr attribute here"
-                                   :notes
-                                   (list
-                                    (make-coalton-error-note
-                                     :type :secondary
-                                     :span (cst:source repr-form)
-                                     :message "previous attribute here")
-                                    (make-coalton-error-note
-                                     :type :secondary
-                                     :span (toplevel-define-struct-head-src struct) 
-                                     :message "when parsing define-struct")))))
+                             :location (cst:source attribute-form)
+                             :message "Duplicate repr attribute"
+                             :primary-note "repr attribute here"
+                             :notes
+                             (list
+                              (source-error:make-note
+                               :type :secondary
+                               :location (cst:source repr-form)
+                               :message "previous attribute here")
+                              (source-error:make-note
+                               :type :secondary
+                               :location (toplevel-define-struct-head-src struct) 
+                               :message "when parsing define-struct"))))
 
                     (unless (eq :transparent (keyword-src-name (attribute-repr-type attribute)))
                       (error 'parse-error
-                             :err (coalton-error
-                                   :span (cst:source attribute-form)
-                                   :file file
-                                   :message "Invalid repr attribute"
-                                   :primary-note "structs can only be repr transparent"
-                                   :notes
-                                   (list
-                                    (make-coalton-error-note
-                                     :type :secondary
-                                     :span (toplevel-define-struct-head-src struct)
-                                     :message "when parsing define-struct")))))
+                             :location (cst:source attribute-form)
+                             :message "Invalid repr attribute"
+                             :primary-note "structs can only be repr transparent"
+                             :notes
+                             (list
+                              (source-error:make-note
+                               :type :secondary
+                               :location (toplevel-define-struct-head-src struct)
+                               :message "when parsing define-struct"))))
 
                     (setf repr attribute)
                     (setf repr-form attribute-form))
 
                    (attribute-monomorphize
                     (error 'parse-error
-                           :err (coalton-error
-                                 :span (cst:source attribute-form)
-                                 :file file
-                                 :message "Invalid target for monomorphize attribute"
-                                 :primary-note "monomorphize must be attached to a define or declare form"
-                                 :notes
-                                 (list
-                                  (make-coalton-error-note
-                                   :type :secondary
-                                   :span (identifier-src-source (toplevel-define-struct-name struct))
-                                   :message "when parsing define-type")))))))
+                           :location (cst:source attribute-form)
+                           :message "Invalid target for monomorphize attribute"
+                           :primary-note "monomorphize must be attached to a define or declare form"
+                           :notes
+                           (list
+                            (source-error:make-note
+                             :type :secondary
+                             :location (identifier-src-source (toplevel-define-struct-name struct))
+                             :message "when parsing define-type"))))))
 
        (setf (fill-pointer attributes) 0)
        (setf (toplevel-define-struct-repr struct) repr)
@@ -855,62 +812,56 @@ consume all attributes"))))
        t))
 
     ((coalton:define-class)
-     (let ((class (parse-define-class form file)))
+     (let ((class (parse-define-class form)))
 
        (unless (zerop (length attributes))
          (error 'parse-error
-                :err (coalton-error
-                      :span (cst:source (cdr (aref attributes 0)))
-                      :file file
-                      :message "Invalid attribute for define-class"
-                      :primary-note "define-class cannot have attributes"
-                      :notes
-                      (list
-                       (make-coalton-error-note
-                        :type :secondary
-                        :span (toplevel-define-class-head-src class)
-                        :message "while parsing define-class")))))
+                :location (cst:source (cdr (aref attributes 0)))
+                :message "Invalid attribute for define-class"
+                :primary-note "define-class cannot have attributes"
+                :notes
+                (list
+                 (source-error:make-note
+                  :type :secondary
+                  :location (toplevel-define-class-head-src class)
+                  :message "while parsing define-class"))))
 
        (push class (program-classes program))
        t))
 
     ((coalton:define-instance)
-     (let ((instance (parse-define-instance form file)))
+     (let ((instance (parse-define-instance form)))
 
        (unless (zerop (length attributes))
          (error 'parse-error
-                :err (coalton-error
-                      :span (cst:source (cdr (aref attributes 0)))
-                      :file file
-                      :message "Invalid attribute for define-instance"
-                      :primary-note "define-instance cannot have attributes"
-                      :notes
-                      (list
-                       (make-coalton-error-note
-                        :type :secondary
-                        :span (toplevel-define-instance-head-src instance)
-                        :message "while parsing define-instance")))))
+                :location (cst:source (cdr (aref attributes 0)))
+                :message "Invalid attribute for define-instance"
+                :primary-note "define-instance cannot have attributes"
+                :notes
+                (list
+                 (source-error:make-note
+                  :type :secondary
+                  :location (toplevel-define-instance-head-src instance)
+                  :message "while parsing define-instance"))))
 
 
        (push instance (program-instances program))
        t))
 
     ((coalton:specialize)
-     (let ((spec (parse-specialize form file)))
+     (let ((spec (parse-specialize form)))
 
        (unless (zerop (length attributes))
          (error 'parse-error
-                :err (coalton-error
-                      :span (cst:source (cdr (aref attributes 0)))
-                      :file file
-                      :message "Invalid attribute for specialize"
-                      :primary-note "specialize cannot have attributes"
-                      :notes
-                      (list
-                       (make-coalton-error-note
-                        :type :secondary
-                        :span (cst:source form)
-                        :message "when parsing specialize")))))
+                :location (cst:source (cdr (aref attributes 0)))
+                :message "Invalid attribute for specialize"
+                :primary-note "specialize cannot have attributes"
+                :notes
+                (list
+                 (source-error:make-note
+                  :type :secondary
+                  :location (cst:source form)
+                  :message "when parsing specialize"))))
 
        (push spec (program-specializations program))
        t))
@@ -918,38 +869,34 @@ consume all attributes"))))
     ((coalton:progn)
      (unless (zerop (length attributes))
        (error 'parse-error
-              :err (coalton-error
-                    :span (cst:source (cdr (aref attributes 0)))
-                    :file file
-                    :message "Invalid attribute for progn"
-                    :primary-note "progn cannot have attributes"
-                    :notes
-                    (list
-                     (make-coalton-error-note
-                      :type :secondary
-                      :span (cst:source form)
-                      :message "when parsing progn")))))
+              :location (cst:source (cdr (aref attributes 0)))
+              :message "Invalid attribute for progn"
+              :primary-note "progn cannot have attributes"
+              :notes
+              (list
+               (source-error:make-note
+                :type :secondary
+                :location (cst:source form)
+                :message "when parsing progn"))))
 
      (loop :for inner-form := (cst:rest form) :then (cst:rest inner-form)
            :while (not (cst:null inner-form)) :do
-             (when (and (parse-toplevel-form (cst:first inner-form) program attributes file)
+             (when (and (parse-toplevel-form (cst:first inner-form) program attributes)
                         (plusp (length attributes)))
                (util:coalton-bug "parse-toplevel-form indicated that a form was parsed but did not
 consume all attributes")))
 
      (unless (zerop (length attributes))
        (error 'parse-error
-              :err (coalton-error
-                    :span (cst:source (cdr (aref attributes 0)))
-                    :file file
-                    :message "Trailing attributes in progn"
-                    :primary-note "progn cannot have trailing attributes"
-                    :notes
-                    (list
-                     (make-coalton-error-note
-                      :type :secondary
-                      :span (cst:source form)
-                      :message "when parsing progn")))))
+              :location (cst:source (cdr (aref attributes 0)))
+              :message "Trailing attributes in progn"
+              :primary-note "progn cannot have trailing attributes"
+              :notes
+              (list
+               (source-error:make-note
+                :type :secondary
+                :location (cst:source form)
+                :message "when parsing progn"))))
      t)
 
     (t
@@ -957,24 +904,18 @@ consume all attributes")))
        ((and (cst:atom (cst:first form))
              (symbolp (cst:raw (cst:first form)))
              (macro-function (cst:raw (cst:first form))))
-        (let ((*coalton-error-context*
-                (adjoin (make-coalton-error-context
-                         :message "Error occurs within macro context. Source locations may be imprecise")
-                        *coalton-error-context*
-                        :test #'equalp)))
-          (parse-toplevel-form (expand-macro form) program attributes file)))
+        (source-error:with-source-context
+            (:macro "Error occurs within macro context. Source locations may be imprecise")
+          (parse-toplevel-form (expand-macro form) program attributes)))
 
        ((error 'parse-error
-               :err (coalton-error
-                     :span (cst:source (cst:first form))
-                     :file file
-                     :message "Invalid toplevel form"
-                     :primary-note "unknown toplevel form")))))))
+               :location (cst:source (cst:first form))
+               :message "Invalid toplevel form"
+               :primary-note "unknown toplevel form"))))))
 
 
-(defun parse-define (form file)
+(defun parse-define (form)
   (declare (type cst:cst form)
-           (type coalton-file file)
            (values toplevel-define))
 
   (assert (cst:consp form))
@@ -982,26 +923,22 @@ consume all attributes")))
   ;; (define)
   (unless (cst:consp (cst:rest form))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source form)
-                 :file file
-                 :message "Malformed definition"
-                 :primary-note "expected define body")))
+           :location (cst:source form)
+           :message "Malformed definition"
+           :primary-note "expected define body"))
 
   ;; (define x)
   (unless (cst:consp (cst:rest (cst:rest form)))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source form)
-                 :file file
-                 :message "Malformed definition"
-                 :primary-note "expected value")))
+           :location (cst:source form)
+           :message "Malformed definition"
+           :primary-note "expected value"))
 
   (multiple-value-bind (name params)
-      (parse-argument-list (cst:second form) file)
+      (parse-argument-list (cst:second form))
 
     (multiple-value-bind (docstring body)
-        (parse-definition-body (cst:rest (cst:rest form)) form file)
+        (parse-definition-body (cst:rest (cst:rest form)) form)
 
       (make-toplevel-define
        :name name
@@ -1012,9 +949,8 @@ consume all attributes")))
        :monomorphize nil
        :source (cst:source form)))))
 
-(defun parse-declare (form file)
+(defun parse-declare (form)
   (declare (type cst:cst form)
-           (type coalton-file file)
            (values toplevel-declare))
 
   (assert (cst:consp form))
@@ -1022,50 +958,41 @@ consume all attributes")))
   ;; (declare)
   (unless (cst:consp (cst:rest form))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source form)
-                 :file file
-                 :message "Malformed declaration"
-                 :primary-note "expected body")))
+           :location (cst:source form)
+           :message "Malformed declaration"
+           :primary-note "expected body"))
 
   ;; (declare x)
   (unless (cst:consp (cst:rest (cst:rest form)))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source form)
-                 :file file
-                 :message "Malformed declaration"
-                 :primary-note "expected declared type")))
+           :location (cst:source form)
+           :message "Malformed declaration"
+           :primary-note "expected declared type"))
 
   ;; (declare x y z)
   (when (cst:consp (cst:rest (cst:rest (cst:rest form))))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source (cst:first (cst:rest (cst:rest (cst:rest form)))))
-                 :file file
-                 :message "Malformed declaration"
-                 :primary-note "unexpected trailing form")))
+           :location (cst:source (cst:first (cst:rest (cst:rest (cst:rest form)))))
+           :message "Malformed declaration"
+           :primary-note "unexpected trailing form"))
 
   ;; (declare 0.5 x)
   (unless (identifierp (cst:raw (cst:second form)))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source (cst:second form))
-                 :file file
-                 :message "Malformed declaration"
-                 :primary-note "expected symbol")))
+           :location (cst:source (cst:second form))
+           :message "Malformed declaration"
+           :primary-note "expected symbol"))
 
   (make-toplevel-declare
    :name (make-identifier-src
           :name (cst:raw (cst:second form))
           :source (cst:source (cst:second form)))
-   :type (parse-qualified-type (cst:third form) file)
+   :type (parse-qualified-type (cst:third form))
    :monomorphize nil
    :source (cst:source form)))
 
-(defun parse-define-type (form file)
+(defun parse-define-type (form)
   (declare (type cst:cst form)
-           (type coalton-file file)
            (values toplevel-define-type))
 
   (assert (cst:consp form))
@@ -1079,21 +1006,17 @@ consume all attributes")))
     ;; (define-type)
     (unless (cst:consp (cst:rest form))
       (error 'parse-error
-             :err (coalton-error
-                   :span (cst:source form)
-                   :file file
-                   :message "Malformed type definition"
-                   :primary-note "expected body")))
+             :location (cst:source form)
+             :message "Malformed type definition"
+             :primary-note "expected body"))
 
     (cond
       ((cst:atom (cst:second form))
        (unless (identifierp (cst:raw (cst:second form)))
          (error 'parse-error
-                :err (coalton-error
-                      :span (cst:source (cst:second form))
-                      :file file
-                      :message "Malformed type definition"
-                      :primary-note "expected symbol")))
+                :location (cst:source (cst:second form))
+                :message "Malformed type definition"
+                :primary-note "expected symbol"))
 
        (setf name (make-identifier-src :name (cst:raw (cst:second form))
                                        :source (cst:source form))))
@@ -1102,28 +1025,24 @@ consume all attributes")))
        ;; (define-type ((T) ...) ...)
        (unless (cst:atom (cst:first (cst:second form)))
          (error 'parse-error
-                :err (coalton-error
-                      :span (cst:source (cst:first (cst:second form)))
-                      :file file
-                      :message "Malformed type definition"
-                      :primary-note "expected symbol"
-                      :help-notes
-                      (list
-                       (make-coalton-error-help
-                        :span (cst:source (cst:second form))
-                        :replacement
-                        (lambda (existing)
-                          (subseq existing 1 (1- (length existing))))
-                        :message "remove parentheses")))))
+                :location (cst:source (cst:first (cst:second form)))
+                :message "Malformed type definition"
+                :primary-note "expected symbol"
+                :help-notes
+                (list
+                 (source-error:make-help
+                  :location (cst:source (cst:second form))
+                  :replacement
+                  (lambda (existing)
+                    (subseq existing 1 (1- (length existing))))
+                  :message "remove parentheses"))))
 
        ;; (define-type (1 ...) ...)
        (unless (identifierp (cst:raw (cst:first (cst:second form))))
          (error 'parse-error
-                :err (coalton-error
-                      :span (cst:source (cst:first (cst:second form)))
-                      :file file
-                      :message "Malformed type definition"
-                      :primary-note "expected symbol")))
+                :location (cst:source (cst:first (cst:second form)))
+                :message "Malformed type definition"
+                :primary-note "expected symbol"))
 
        (setf name (make-identifier-src :name (cst:raw (cst:first (cst:second form)))
                                        :source (cst:source (cst:first (cst:second form)))))
@@ -1131,23 +1050,21 @@ consume all attributes")))
        ;; (define-type (T) ...)
        (when (cst:atom (cst:rest (cst:second form)))
          (error 'parse-error
-                :err (coalton-error
-                      :span (cst:source (cst:second form))
-                      :file file
-                      :message "Malformed type definition"
-                      :primary-note "nullary types should not have parentheses"
-                      :help-notes
-                      (list
-                       (make-coalton-error-help
-                        :span (cst:source (cst:second form))
-                        :replacement
-                        (lambda (existing)
-                          (subseq existing 1 (1- (length existing))))
-                        :message "remove unnecessary parentheses")))))
+                :location (cst:source (cst:second form))
+                :message "Malformed type definition"
+                :primary-note "nullary types should not have parentheses"
+                :help-notes
+                (list
+                 (source-error:make-help
+                  :location (cst:source (cst:second form))
+                  :replacement
+                  (lambda (existing)
+                    (subseq existing 1 (1- (length existing))))
+                  :message "remove unnecessary parentheses"))))
 
        (loop :for vars := (cst:rest (cst:second form)) :then (cst:rest vars)
              :while (cst:consp vars)
-             :do (push (parse-type-variable (cst:first vars) file) variables))))
+             :do (push (parse-type-variable (cst:first vars)) variables))))
 
     (when (and (cst:consp (cst:rest (cst:rest form)))
                (cst:atom (cst:third form))
@@ -1160,17 +1077,16 @@ consume all attributes")))
      :docstring docstring
      :ctors (loop :for constructors_ := (cst:nthrest (if docstring 3 2) form) :then (cst:rest constructors_)
                   :while (cst:consp constructors_)
-                  :collect (parse-constructor (cst:first constructors_) form file))
+                  :collect (parse-constructor (cst:first constructors_) form))
      :repr nil
      :source (cst:source form)
      :head-src (cst:source (cst:second form)))))
 
-(defun parse-define-struct (form file)
-  (declare (type cst:cst form)
-           (type coalton-file file))
-
+(defun parse-define-struct (form)
+  (declare (type cst:cst form))
+  
   (assert (cst:consp form))
-
+  
   (let (unparsed-name
         unparsed-variables
         docstring)
@@ -1178,12 +1094,9 @@ consume all attributes")))
     ;; (define-struct)
     (unless (cst:consp (cst:rest form))
       (error 'parse-error
-             :err (coalton-error
-                   :span (cst:source form)
-                   :file file
-                   :message "Malformed struct definition"
-                   :primary-note "expected body"
-                   :highlight :end)))
+             :location (util:source-end form)
+             :message "Malformed struct definition"
+             :primary-note "expected body"))
 
     (if (cst:atom (cst:second form))
         ;; (deine-struct S ...)
@@ -1201,21 +1114,20 @@ consume all attributes")))
       (setf docstring (cst:raw (cst:third form))))
 
     (make-toplevel-define-struct
-     :name (parse-identifier unparsed-name file)
+     :name (parse-identifier unparsed-name)
      :vars (when unparsed-variables
-             (parse-list #'parse-type-variable unparsed-variables file)) 
+             (parse-list #'parse-type-variable unparsed-variables)) 
      :docstring docstring
      :fields (parse-list
               #'parse-struct-field
               (cst:nthrest (if docstring 3 2) form)
-              file)
+              )
      :source (cst:source form)
      :repr nil
      :head-src (cst:source (cst:second form)))))
 
-(defun parse-define-class (form file)
+(defun parse-define-class (form)
   (declare (type cst:cst form)
-           (type coalton-file file)
            (values toplevel-define-class))
 
   (assert (cst:consp form))
@@ -1232,36 +1144,30 @@ consume all attributes")))
     ;; (define-class)
     (unless (cst:consp (cst:rest form))
       (error 'parse-error
-             :err (coalton-error
-                   :span (cst:source form)
-                   :file file
-                   :message "Malformed class definition"
-                   :primary-note "expected body")))
+             :location (cst:source form)
+             :message "Malformed class definition"
+             :primary-note "expected body"))
 
     ;; (define-class C)
     (unless (cst:consp (cst:second form))
       (error 'parse-error
-             :err (coalton-error
-                   :span (cst:source (cst:second form))
-                   :file file
-                   :message "Malformed class definition"
-                   :primary-note "expected class type variable(s)"
-                   :help-notes
-                   (list
-                    (make-coalton-error-help
-                     :span (cst:source (cst:second form))
-                     :replacement
-                     (lambda (existing)
-                       (concatenate 'string "(" existing " :a)"))
-                     :message "add class type variable `:a`")))))
+             :location (cst:source (cst:second form))
+             :message "Malformed class definition"
+             :primary-note "expected class type variable(s)"
+             :help-notes
+             (list
+              (source-error:make-help
+               :location (cst:source (cst:second form))
+               :replacement
+               (lambda (existing)
+                 (concatenate 'string "(" existing " :a)"))
+               :message "add class type variable `:a`"))))
 
     (unless (cst:proper-list-p (cst:second form))
       (error 'parse-error
-             :err (coalton-error
-                   :span (cst:source (cst:second form))
-                   :file file
-                   :message "Malformed class definition"
-                   :primary-note "unexpected dotted list")))
+             :location (cst:source (cst:second form))
+             :message "Malformed class definition"
+             :primary-note "unexpected dotted list"))
 
     (multiple-value-bind (left right)
         (util:take-until (lambda (cst)
@@ -1272,44 +1178,40 @@ consume all attributes")))
       ;; (=> C ...)
       (when (and (null left) right)
         (error 'parse-error
-               :err (coalton-error
-                     :span (cst:source (cst:first (cst:second form)))
-                     :file file
-                     :message "Malformed class definition"
-                     :primary-note "unnecessary `=>`"
-                     :help-notes
-                     (cond
-                       ;; If this is the only thing in the list then don't suggest anything
-                       ((cst:atom (cst:rest (cst:second form)))
-                        nil)
-                       ;; If there is nothing to the right of C then emit without list
-                       ((cst:atom (cst:rest (cst:rest (cst:second form))))
-                        (list
-                         (make-coalton-error-help
-                          :span (cst:source (cst:second form))
-                          :replacement
-                          (lambda (existing)
-                            (subseq existing 4 (1- (length existing))))
-                          :message "remove `=>`")))
-                       (t
-                        (list
-                         (make-coalton-error-help
-                          :span (cst:source (cst:second form))
-                          :replacement
-                          (lambda (existing)
-                            (concatenate 'string
-                                         (subseq existing 0 1)
-                                         (subseq existing 4)))
-                          :message "remove `=>`")))))))
+               :location (cst:source (cst:first (cst:second form)))
+               :message "Malformed class definition"
+               :primary-note "unnecessary `=>`"
+               :help-notes
+               (cond
+                 ;; If this is the only thing in the list then don't suggest anything
+                 ((cst:atom (cst:rest (cst:second form)))
+                  nil)
+                 ;; If there is nothing to the right of C then emit without list
+                 ((cst:atom (cst:rest (cst:rest (cst:second form))))
+                  (list
+                   (source-error:make-help
+                    :location (cst:source (cst:second form))
+                    :replacement
+                    (lambda (existing)
+                      (subseq existing 4 (1- (length existing))))
+                    :message "remove `=>`")))
+                 (t
+                  (list
+                   (source-error:make-help
+                    :location (cst:source (cst:second form))
+                    :replacement
+                    (lambda (existing)
+                      (concatenate 'string
+                                   (subseq existing 0 1)
+                                   (subseq existing 4)))
+                    :message "remove `=>`"))))))
 
       ;; (... =>)
       (when (and left right (null (cdr right)))
         (error 'parse-error
-               :err (coalton-error
-                     :span (cst:source (cst:second form))
-                     :file file
-                     :message "Malformed class definition"
-                     :primary-note "missing class name")))
+               :location (cst:source (cst:second form))
+               :message "Malformed class definition"
+               :primary-note "missing class name"))
 
       (cond
         ;; No predicates
@@ -1321,11 +1223,9 @@ consume all attributes")))
         ((and (cst:consp (second right))
               (consp (cdr (cdr right))))
          (error 'parse-error
-                :err (coalton-error
-                      :span (cst:source (third right))
-                      :file file
-                      :message "Malformed class definition"
-                      :primary-note "unexpected form")))
+                :location (cst:source (third right))
+                :message "Malformed class definition"
+                :primary-note "unexpected form"))
 
         ;; (... => (...))
         ((cst:consp (second right))
@@ -1341,47 +1241,41 @@ consume all attributes")))
       ;; (define-class ((C) ...))
       (unless (cst:atom unparsed-name)
         (error 'parse-error
-               :err (coalton-error
-                     :span (cst:source unparsed-name)
-                     :file file
-                     :message "Malformed class definition"
-                     :primary-note "unnecessary parentheses"
-                     :help-notes
-                     (list
-                      (make-coalton-error-help
-                       :span (cst:source unparsed-name)
-                       :replacement
-                       (lambda (existing)
-                         (subseq existing 1 (1- (length existing))))
-                       :message "remove unnecessary parentheses")))))
+               :location (cst:source unparsed-name)
+               :message "Malformed class definition"
+               :primary-note "unnecessary parentheses"
+               :help-notes
+               (list
+                (source-error:make-help
+                 :location (cst:source unparsed-name)
+                 :replacement
+                 (lambda (existing)
+                   (subseq existing 1 (1- (length existing))))
+                 :message "remove unnecessary parentheses"))))
 
       (unless (identifierp (cst:raw unparsed-name))
         (error 'parse-error
-               :err (coalton-error
-                     :span (cst:source unparsed-name)
-                     :file file
-                     :message "Malformed class definition"
-                     :primary-note "expected symbol")))
+               :location (cst:source unparsed-name)
+               :message "Malformed class definition"
+               :primary-note "expected symbol"))
 
       (setf name (cst:raw unparsed-name))
 
       (when (null unparsed-variables)
         (error 'parse-error
-               :err (coalton-error
-                     :span (cst:source unparsed-name)
-                     :file file
-                     :message "Malformed class definition"
-                     :primary-note "expected class type variable(s)"
-                     :help-notes
-                     (list
-                      (make-coalton-error-help
-                       :span (cst:source unparsed-name)
-                       :replacement
-                       (lambda (existing)
-                         (if (cst:consp (cst:second form))
-                             (concatenate 'string existing " :a")
-                             (concatenate 'string "(" existing " :a)")))
-                       :message "add class type variable `:a`")))))
+               :location (cst:source unparsed-name)
+               :message "Malformed class definition"
+               :primary-note "expected class type variable(s)"
+               :help-notes
+               (list
+                (source-error:make-help
+                 :location (cst:source unparsed-name)
+                 :replacement
+                 (lambda (existing)
+                   (if (cst:consp (cst:second form))
+                       (concatenate 'string existing " :a")
+                       (concatenate 'string "(" existing " :a)")))
+                 :message "add class type variable `:a`"))))
 
 
       (multiple-value-bind (left right)
@@ -1389,22 +1283,22 @@ consume all attributes")))
 
         (setf variables
               (loop :for var :in left
-                    :collect (parse-type-variable var file)))
+                    :collect (parse-type-variable var)))
 
         (setf fundeps
               (loop :for fundep :in right
-                    :collect (parse-fundep fundep file))))
+                    :collect (parse-fundep fundep))))
 
       ;; (... => C ...)
       (when right
         (if (cst:atom (first left))
             ;; (C1 ... => C2 ...)
-            (setf predicates (list (parse-predicate left (util:cst-source-range left) file)))
+            (setf predicates (list (parse-predicate left (util:source-range left))))
 
             ;; ((C1 ...) (C2 ...) ... => C3 ...)
             (setf predicates
                   (loop :for pred :in left
-                        :collect (parse-predicate (cst:listify pred) (cst:source pred) file)))))
+                        :collect (parse-predicate (cst:listify pred) (cst:source pred))))))
 
       (when (and (cst:consp (cst:rest (cst:rest form)))
                  (cst:atom (cst:third form))
@@ -1414,7 +1308,7 @@ consume all attributes")))
       (setf methods
             (loop :for methods := (cst:nthrest (if docstring 3 2) form) :then (cst:rest methods)
                   :while (cst:consp methods)
-                  :collect (parse-method (cst:first methods) form file)))
+                  :collect (parse-method (cst:first methods) form)))
 
       (make-toplevel-define-class
        :name (make-identifier-src
@@ -1428,9 +1322,8 @@ consume all attributes")))
        :source (cst:source form)
        :head-src (cst:source (cst:second form))))))
 
-(defun parse-define-instance (form file)
+(defun parse-define-instance (form)
   (declare (type cst:cst form)
-           (type coalton-file file)
            (values toplevel-define-instance))
 
   (assert (cst:consp form))
@@ -1443,29 +1336,22 @@ consume all attributes")))
     ;; (define-instance)
     (unless (cst:consp (cst:rest form))
       (error 'parse-error
-             :err (coalton-error
-                   :span (cst:source form)
-                   :file file
-                   :highlight :end
-                   :message "Malformed instance definition"
-                   :primary-note "expected an instance head")))
+             :location (util:source-end form)
+             :message "Malformed instance definition"
+             :primary-note "expected an instance head"))
 
     ;; (define-instance 5)
     (unless (cst:consp (cst:second form))
       (error 'parse-error
-             :err (coalton-error
-                   :span (cst:source (cst:second form))
-                   :file file
-                   :message "Malformed instance definition"
-                   :primary-note "expected a list")))
+             :location (cst:source (cst:second form))
+             :message "Malformed instance definition"
+             :primary-note "expected a list"))
 
     (unless (cst:proper-list-p (cst:second form))
       (error 'parse-error
-             :err (coalton-error
-                   :span (cst:source (cst:second form))
-                   :file file
-                   :message "Malformed instance definition"
-                   :primary-note "unexpected dotted list")))
+             :location (cst:source (cst:second form))
+             :message "Malformed instance definition"
+             :primary-note "unexpected dotted list"))
 
     (multiple-value-bind (left right)
         (util:take-until
@@ -1484,11 +1370,9 @@ consume all attributes")))
               (cst:consp (second right))
               (consp (cdr (cdr right))))
          (error 'parse-error
-                :err (coalton-error
-                      :span (cst:source (third right))
-                      :file file
-                      :message "Malformed instance definition"
-                      :primary-note "unexpected form")))
+                :location (cst:source (third right))
+                :message "Malformed instance definition"
+                :primary-note "unexpected form"))
 
         ;; (.... => (...))
         ((and (second right)
@@ -1504,46 +1388,42 @@ consume all attributes")))
       ;; (... =>)
       (when (and left right (null (cdr right)))
         (error 'parse-error
-               :err (coalton-error
-                     :span (cst:source (first right))
-                     :file file
-                     :message "Malformed instance head"
-                     :primary-note "unexpected `=>`"
-                     :help-notes
-                     (list
-                      (make-coalton-error-help
-                       :span (cst:source (first right))
-                       :replacement
-                       (lambda (existing)
-                         (declare (ignore existing))
-                         "")
-                       :message "remove the `=>`")))))
+               :location (cst:source (first right))
+               :message "Malformed instance head"
+               :primary-note "unexpected `=>`"
+               :help-notes
+               (list
+                (source-error:make-help
+                 :location (cst:source (first right))
+                 :replacement
+                 (lambda (existing)
+                   (declare (ignore existing))
+                   "")
+                 :message "remove the `=>`"))))
 
       ;; (=> ...)
       (when (and (null left) right)
         (error 'parse-error
-               :err (coalton-error
-                     :span (cst:source (first right))
-                     :file file
-                     :message "Malformed instance head"
-                     :primary-note "unexpected `=>`"
-                     :help-notes
-                     (list
-                      (make-coalton-error-help
-                       :span (cst:source (first right))
-                       :replacement
-                       (lambda (existing)
-                         (declare (ignore existing))
-                         "")
-                       :message "remove the `=>`")))))
+               :location (cst:source (first right))
+               :message "Malformed instance head"
+               :primary-note "unexpected `=>`"
+               :help-notes
+               (list
+                (source-error:make-help
+                 :location (cst:source (first right))
+                 :replacement
+                 (lambda (existing)
+                   (declare (ignore existing))
+                   "")
+                 :message "remove the `=>`"))))
 
       (when unparsed-context
         (if (cst:atom (first unparsed-context))
-            (setf context (list (parse-predicate unparsed-context (util:cst-source-range unparsed-context) file)))
+            (setf context (list (parse-predicate unparsed-context (util:source-range unparsed-context))))
 
             (setf context
                   (loop :for unparsed :in unparsed-context
-                        :collect (parse-predicate (cst:listify unparsed) (cst:source unparsed) file)))))
+                        :collect (parse-predicate (cst:listify unparsed) (cst:source unparsed))))))
 
       (when (and (cst:consp (cst:rest (cst:rest form)))
                  (cst:atom (cst:third form))
@@ -1552,19 +1432,18 @@ consume all attributes")))
 
       (make-toplevel-define-instance
        :context context
-       :pred (parse-predicate unparsed-predicate (util:cst-source-range unparsed-predicate) file)
+       :pred (parse-predicate unparsed-predicate (util:source-range unparsed-predicate))
        :docstring docstring
        :methods (loop :for methods := (cst:nthrest (if docstring 3 2) form) :then (cst:rest methods)
                       :while (cst:consp methods)
                       :for method := (cst:first methods)
-                      :collect (parse-instance-method-definition method (cst:second form) file))
+                      :collect (parse-instance-method-definition method (cst:second form)))
        :source (cst:source form)
        :head-src (cst:source (cst:second form))
        :compiler-generated nil))))
 
-(defun parse-specialize (form file)
+(defun parse-specialize (form)
   (declare (type cst:cst form)
-           (type coalton-file file)
            (values toplevel-specialize))
 
   (assert (cst:consp form))
@@ -1572,146 +1451,122 @@ consume all attributes")))
   ;; (specialize)
   (unless (cst:consp (cst:rest form))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source form)
-                 :file file
-                 :highlight :end
-                 :message "Malformed specialize declaration"
-                 :primary-note "missing from name")))
+           :location (util:source-end form)
+           :message "Malformed specialize declaration"
+           :primary-note "missing from name"))
 
   ;; (specialize f)
   (unless (cst:consp (cst:rest (cst:rest form)))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source form)
-                 :file file
-                 :highlight :end
-                 :message "Malformed specialize declaration"
-                 :primary-note "missing to name")))
+           :location (util:source-end form)
+           :message "Malformed specialize declaration"
+           :primary-note "missing to name"))
 
   ;; (specialize f f2)
   (unless (cst:consp (cst:rest (cst:rest (cst:rest form))))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source form)
-                 :file file
-                 :highlight :end
-                 :message "Malformed specialize declaration"
-                 :primary-note "missing type")))
+           :location (util:source-end form)
+           :message "Malformed specialize declaration"
+           :primary-note "missing type"))
 
   ;; (specialize f f2 t ....)
   (when (cst:consp (cst:rest (cst:rest (cst:rest (cst:rest form)))))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source (cst:first (cst:rest (cst:rest (cst:rest (cst:rest form))))))
-                 :file file
-                 :message "Malformed specialize declaration"
-                 :primary-note "unexpected form")))
+           :location (cst:source (cst:first (cst:rest (cst:rest (cst:rest (cst:rest form))))))
+           :message "Malformed specialize declaration"
+           :primary-note "unexpected form"))
 
   (make-toplevel-specialize
-   :from (parse-variable (cst:second form) file)
-   :to (parse-variable (cst:third form) file)
-   :type (parse-type (cst:fourth form) file)
+   :from (parse-variable (cst:second form))
+   :to (parse-variable (cst:third form))
+   :type (parse-type (cst:fourth form))
    :source (cst:source form)))
 
-(defun parse-method (method-form form file)
+(defun parse-method (method-form form)
   (declare (type cst:cst method-form)
-           (type coalton-file file)
            (values method-definition))
 
   ;; m or (m)
   (unless (and (cst:consp method-form)
                (cst:consp (cst:rest method-form)))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source method-form)
-                 :file file
-                 :message "Malformed method definition"
-                 :primary-note "missing method type"
-                 :notes
-                 (list
-                  (make-coalton-error-note
-                   :type :secondary
-                   :span (cst:source (cst:second form))
-                   :message "in this class definition")))))
+           :location (cst:source method-form)
+           :message "Malformed method definition"
+           :primary-note "missing method type"
+           :notes
+           (list
+            (source-error:make-note
+             :type :secondary
+             :location (cst:source (cst:second form))
+             :message "in this class definition"))))
 
   ;; (m t ...)
   (when (cst:consp (cst:rest (cst:rest method-form)))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source (cst:first (cst:rest (cst:rest method-form))))
-                 :file file
-                 :message "Malformed method definition"
-                 :primary-note "unexpected trailing form"
-                 :notes
-                 (list
-                  (make-coalton-error-note
-                   :type :secondary
-                   :span (cst:source (cst:second form))
-                   :message "in this class definition")))))
+           :location (cst:source (cst:first (cst:rest (cst:rest method-form))))
+           :message "Malformed method definition"
+           :primary-note "unexpected trailing form"
+           :notes
+           (list
+            (source-error:make-note
+             :type :secondary
+             :location (cst:source (cst:second form))
+             :message "in this class definition"))))
 
   ;; (0.5 t ...)
   (unless (and (cst:atom (cst:first method-form))
                (identifierp (cst:raw (cst:first method-form))))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source (cst:first method-form))
-                 :file file
-                 :message "Malformed method definition"
-                 :primary-note "expected symbol"
-                 :notes
-                 (list
-                  (make-coalton-error-note
-                   :type :secondary
-                   :span (cst:source (cst:second form))
-                   :message "in this class definition")))))
+           :location (cst:source (cst:first method-form))
+           :message "Malformed method definition"
+           :primary-note "expected symbol"
+           :notes
+           (list
+            (source-error:make-note
+             :type :secondary
+             :location (cst:source (cst:second form))
+             :message "in this class definition"))))
 
   (make-method-definition
    :name (make-identifier-src
-          :name (node-variable-name (parse-variable (cst:first method-form) file))
+          :name (node-variable-name (parse-variable (cst:first method-form)))
           :source (cst:source (cst:first method-form)))
-   :type (parse-qualified-type (cst:second method-form) file)
+   :type (parse-qualified-type (cst:second method-form))
    :source (cst:source method-form)))
 
 
-(defun parse-type-variable (form file)
+(defun parse-type-variable (form)
   (declare (type cst:cst form)
-           (type coalton-file file)
            (values keyword-src &optional))
 
   (when (cst:consp form)
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source form)
-                 :file file
-                 :message "Invalid type variable"
-                 :primary-note "expected keyword symbol")))
+           :location (cst:source form)
+           :message "Invalid type variable"
+           :primary-note "expected keyword symbol"))
 
   (unless (keywordp (cst:raw form))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source form)
-                 :file file
-                 :message "Invalid type variable"
-                 :primary-note "expected keyword symbol"
-                 :help-notes
-                 (cond
-                   ((eq *package* (symbol-package (cst:raw form)))
-                    (list
-                     (make-coalton-error-help
-                      :span (cst:source form)
-                      :replacement
-                      (lambda (existing)
-                        (concatenate 'string ":" existing))
-                      :message "add `:` to symbol")))))))
+           :location (cst:source form)
+           :message "Invalid type variable"
+           :primary-note "expected keyword symbol"
+           :help-notes
+           (cond
+             ((eq *package* (symbol-package (cst:raw form)))
+              (list
+               (source-error:make-help
+                :location (cst:source form)
+                :replacement
+                (lambda (existing)
+                  (concatenate 'string ":" existing))
+                :message "add `:` to symbol"))))))
 
   (make-keyword-src
    :name (cst:raw form)
    :source (cst:source form)))
 
-(defun parse-constructor (form enclosing-form file)
+(defun parse-constructor (form enclosing-form)
   (declare (type cst:cst form enclosing-form)
-           (type coalton-file file)
            (values constructor))
 
   (let (unparsed-name
@@ -1725,114 +1580,97 @@ consume all attributes")))
 
     (unless (cst:atom unparsed-name)
       (error 'parse-error
-             :err (coalton-error
-                   :span (cst:source unparsed-name)
-                   :file file
-                   :message "Malformed constructor"
-                   :primary-note "expected symbol"
-                   :notes
-                   (list
-                    (make-coalton-error-note
-                     :type :secondary
-                     :span (cst:source (cst:second enclosing-form))
-                     :message "in this type definition")))))
+             :location (cst:source unparsed-name)
+             :message "Malformed constructor"
+             :primary-note "expected symbol"
+             :notes
+             (list
+              (source-error:make-note
+               :type :secondary
+               :location (cst:source (cst:second enclosing-form))
+               :message "in this type definition"))))
 
     (unless (identifierp (cst:raw unparsed-name))
       (error 'parse-error
-             :err (coalton-error
-                   :span (cst:source unparsed-name)
-                   :file file
-                   :message "Malformed constructor"
-                   :primary-note "expected symbol"
-                   :notes
-                   (list
-                    (make-coalton-error-note
-                     :type :secondary
-                     :span (cst:source (cst:second enclosing-form))
-                     :message "in this type definition")))))
+             :location (cst:source unparsed-name)
+             :message "Malformed constructor"
+             :primary-note "expected symbol"
+             :notes
+             (list
+              (source-error:make-note
+               :type :secondary
+               :location (cst:source (cst:second enclosing-form))
+               :message "in this type definition"))))
 
     (make-constructor
      :name (make-identifier-src
             :name (cst:raw unparsed-name)
             :source (cst:source unparsed-name))
      :fields (loop :for field :in unparsed-fields
-                   :collect (parse-type field file))
+                   :collect (parse-type field))
      :source (cst:source form))))
 
 
-(defun parse-argument-list (form file)
+(defun parse-argument-list (form)
   (declare (type cst:cst form)
-           (type coalton-file file)
            (values node-variable pattern-list))
 
   ;; (define x 1)
   (when (cst:atom form)
-    (return-from parse-argument-list (values (parse-variable form file) nil)))
+    (return-from parse-argument-list (values (parse-variable form) nil)))
 
   ;; (define (0.5 x y) ...)
   (unless (identifierp (cst:raw (cst:first form)))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source (cst:first form))
-                 :file file
-                 :message "Malformed function definition"
-                 :primary-note "expected symbol")))
+           :location (cst:source (cst:first form))
+           :message "Malformed function definition"
+           :primary-note "expected symbol"))
 
   (values
-   (parse-variable (cst:first form) file)
+   (parse-variable (cst:first form))
    (if (cst:null (cst:rest form))
        (list
         (make-pattern-wildcard
          :source (cst:source form)))
        (loop :for vars := (cst:rest form) :then (cst:rest vars)
              :while (cst:consp vars)
-             :collect (parse-pattern (cst:first vars) file)))))
+             :collect (parse-pattern (cst:first vars))))))
 
-(defun parse-identifier (form file)
+(defun parse-identifier (form)
   (declare (type cst:cst form)
-           (type coalton-file file)
            (values identifier-src))
 
   (unless (cst:atom form)
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source form)
-                 :file file
-                 :message "Unexpected list"
-                 :primary-note "expected an identifier")))
+           :location (cst:source form)
+           :message "Unexpected list"
+           :primary-note "expected an identifier"))
 
   (unless (identifierp (cst:raw form))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source form)
-                 :file file
-                 :message "Unexpected form"
-                 :primary-note "expected an identifier")))
+           :location (cst:source form)
+           :message "Unexpected form"
+           :primary-note "expected an identifier"))
 
   (when (string= "_" (symbol-name (cst:raw form)))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source form)
-                 :file file
-                 :message "Invalid identifier"
-                 :primary-note "invalid identifier '_'")))
+           :location (cst:source form)
+           :message "Invalid identifier"
+           :primary-note "invalid identifier '_'"))
 
   (when (char= #\. (aref (symbol-name (cst:raw form)) 0))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source form)
-                 :file file
-                 :message "Invalid identifier"
-                 :primary-note "identifiers cannot start with '.'")))
+           :location (cst:source form)
+           :message "Invalid identifier"
+           :primary-note "identifiers cannot start with '.'"))
 
   (make-identifier-src
    :name (cst:raw form)
    :source (cst:source form)))
 
-(defun parse-definition-body (form enclosing-form file)
+(defun parse-definition-body (form enclosing-form)
   (declare (type cst:cst form)
            (type cst:cst enclosing-form)
-           (type coalton-file file)
            (values (or null string) node-body))
 
   (let (docstring
@@ -1840,7 +1678,7 @@ consume all attributes")))
 
     ;; (define y 2)
     (when (cst:atom (cst:rest form))
-      (return-from parse-definition-body (values nil (parse-body form enclosing-form file))))
+      (return-from parse-definition-body (values nil (parse-body form enclosing-form))))
 
     (if (and (cst:atom (cst:first form))
              (stringp (cst:raw (cst:first form))))
@@ -1850,86 +1688,72 @@ consume all attributes")))
 
         (setf unparsed-body form))
 
-    (values docstring (parse-body unparsed-body enclosing-form file))))
+    (values docstring (parse-body unparsed-body enclosing-form))))
 
-(defun parse-instance-method-definition (form parent-form file)
+(defun parse-instance-method-definition (form parent-form)
   (declare (type cst:cst form)
            (type cst:cst parent-form)
-           (type coalton-file file)
            (values instance-method-definition))
 
   (let ((context-note
-          (make-coalton-error-note
+          (source-error:make-note
            :type :secondary
-           :span (cst:source parent-form)
+           :location (cst:source parent-form)
            :message "when parsing instance")))
 
     (unless (cst:consp form)
       (error 'parse-error
-             :err (coalton-error
-                   :span (cst:source form)
-                   :file file
-                   :message "Malformed method definition"
-                   :primary-note "expected list"
-                   :notes (list context-note))))
+             :location (cst:source form)
+             :message "Malformed method definition"
+             :primary-note "expected list"
+             :notes (list context-note)))
 
     (unless (cst:proper-list-p form)
       (error 'parse-error
-             :err (coalton-error
-                   :span (cst:source form)
-                   :file file
-                   :message "Malformed method definition"
-                   :primary-note "unexpected dotted list"
-                   :notes (list context-note))))
+             :location (cst:source form)
+             :message "Malformed method definition"
+             :primary-note "unexpected dotted list"
+             :notes (list context-note)))
 
     (unless (and (cst:atom (cst:first form))
                  (eq (cst:raw (cst:first form)) 'coalton:define))
       (error 'parse-error
-             :err (coalton-error
-                   :span (cst:source (cst:first form))
-                   :file file
-                   :message "Malformed method definition"
-                   :primary-note "expected method definition"
-                   :notes (list context-note))))
+             :location (cst:source (cst:first form))
+             :message "Malformed method definition"
+             :primary-note "expected method definition"
+             :notes (list context-note)))
 
     (unless (cst:consp (cst:rest form))
       (error 'parse-error
-             :err (coalton-error
-                   :span (cst:source form)
-                   :file file
-                   :message "Malformed method definition"
-                   :primary-note "expected definition name"
-                   :notes (list context-note))))
+             :location (cst:source form)
+             :message "Malformed method definition"
+             :primary-note "expected definition name"
+             :notes (list context-note)))
 
     (multiple-value-bind (name params)
-        (parse-argument-list (cst:second form) file)
+        (parse-argument-list (cst:second form))
 
       (make-instance-method-definition
        :name name
        :params params
-       :body (parse-body (cst:rest (cst:rest form)) form file)
+       :body (parse-body (cst:rest (cst:rest form)) form)
        :source (cst:source form)))))
 
-(defun parse-fundep (form file)
+(defun parse-fundep (form)
   (declare (type cst:cst form)
-           (type coalton-file file)
            (values fundep))
 
   (unless (cst:consp form)
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source form)
-                 :file file
-                 :message "Malformed functional dependency"
-                 :primary-note "expected a list")))
+           :location (cst:source form)
+           :message "Malformed functional dependency"
+           :primary-note "expected a list"))
 
   (unless (cst:proper-list-p form)
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source form)
-                 :file file
-                 :message "Malformed functional dependency"
-                 :primary-note "unexpected dotted list")))
+           :location (cst:source form)
+           :message "Malformed functional dependency"
+           :primary-note "unexpected dotted list"))
 
   (multiple-value-bind (left right)
       (util:take-until
@@ -1940,83 +1764,66 @@ consume all attributes")))
 
     (unless left
       (error 'parse-error
-             :err (coalton-error
-                   :span (cst:source form)
-                   :file file
-                   :message "Malformed functional dependency"
-                   :primary-note "expected one or more type variables")))
+             :location (cst:source form)
+             :message "Malformed functional dependency"
+             :primary-note "expected one or more type variables"))
 
     (unless (rest right)
       (error 'parse-error
-             :err (coalton-error
-                   :span (cst:source form)
-                   :file file
-                   :highlight :end
-                   :message "Malformed functional dependency"
-                   :primary-note "expected one or more type variables")))
+             :location (util:source-end form)
+             :message "Malformed functional dependency"
+             :primary-note "expected one or more type variables"))
 
     (make-fundep
      :left (loop :for var :in left
-                 :collect (parse-type-variable var file))
+                 :collect (parse-type-variable var))
      :right (loop :for var :in (cdr right)
-                  :collect (parse-type-variable var file))
+                  :collect (parse-type-variable var))
      :source (cst:source form))))
 
 
-(defun parse-monomorphize (form file)
+(defun parse-monomorphize (form)
   (declare (type cst:cst form)
-           (type coalton-file file)
            (values attribute-monomorphize))
 
   (assert (cst:consp form))
 
   (when (cst:consp (cst:rest form))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source form)
-                 :file file
-                 :message "Malformed monomophize attribute"
-                 :primary-note "unexpected form")))
+           :location (cst:source form)
+           :message "Malformed monomophize attribute"
+           :primary-note "unexpected form"))
 
   (make-attribute-monomorphize
    :source (cst:source form)))
 
-(defun parse-repr (form file)
+(defun parse-repr (form)
   (declare (type cst:cst form)
-           (type coalton-file file)
            (values attribute-repr))
 
   (assert (cst:consp form))
 
   (unless (cst:consp (cst:rest form))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source form)
-                 :file file
-                 :highlight :end
-                 :message "Malformed repr attribute"
-                 :primary-note "expected keyword symbol")))
+           :location (util:source-end form)
+           :message "Malformed repr attribute"
+           :primary-note "expected keyword symbol"))
 
-  (let ((type (parse-type-variable (cst:second form) file)))
+  (let ((type (parse-type-variable (cst:second form))))
     (if (eq (keyword-src-name type) :native)
 
         (progn ;; :native reprs must have an argument
           (unless (cst:consp (cst:rest (cst:rest form)))
             (error 'parse-error
-                   :err (coalton-error
-                         :span (cst:source form)
-                         :file file
-                         :highlight :end
-                         :message "Malformed repr :native attribute"
-                         :primary-note "expected a lisp type")))
+                   :location (util:source-end form)
+                   :message "Malformed repr :native attribute"
+                   :primary-note "expected a lisp type"))
 
           (when (cst:consp (cst:rest (cst:rest (cst:rest form))))
             (error 'parse-error
-                   :err (coalton-error
-                         :span (cst:source (cst:first (cst:rest (cst:rest (cst:rest form)))))
-                         :file file
-                         :message "Malformed repr :native attribute"
-                         :primary-note "unexpected form")))
+                   :location (cst:source (cst:first (cst:rest (cst:rest (cst:rest form)))))
+                   :message "Malformed repr :native attribute"
+                   :primary-note "unexpected form"))
 
           (make-attribute-repr
            :type type
@@ -2026,11 +1833,9 @@ consume all attributes")))
         (progn ;; other reprs do not have an argument
           (when (cst:consp (cst:rest (cst:rest form)))
             (error 'parse-error
-                   :err (coalton-error
-                         :span (cst:source (cst:first (cst:rest (cst:rest form))))
-                         :file file
-                         :message "Malformed repr attribute"
-                         :primary-note "unexpected form")))
+                   :location (cst:source (cst:first (cst:rest (cst:rest form))))
+                   :message "Malformed repr attribute"
+                   :primary-note "unexpected form"))
 
           (case (keyword-src-name type)
             (:lisp nil)
@@ -2038,62 +1843,49 @@ consume all attributes")))
             (:enum nil)
             (t
              (error 'parse-error
-                    :err (coalton-error
-                          :span (cst:source (cst:second form))
-                          :file file
-                          :message "Unknown repr attribute"
-                          :primary-note "expected one of :lisp, :transparent, :enum, or :native"))))
+                    :location (cst:source (cst:second form))
+                    :message "Unknown repr attribute"
+                    :primary-note "expected one of :lisp, :transparent, :enum, or :native")))
 
           (make-attribute-repr
            :type type
            :arg nil
            :source (cst:source form))))))
 
-(defun parse-struct-field (form file)
+(defun parse-struct-field (form)
   (declare (type cst:cst form)
-           (type coalton-file file)
            (values struct-field))
 
   ;; 5
   (unless (cst:consp form)
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source form)
-                 :file file
-                 :message "Malformed struct field"
-                 :primary-note "expected field name")))
+           :location (cst:source form)
+           :message "Malformed struct field"
+           :primary-note "expected field name"))
 
   ;; (name)
   (unless (cst:consp (cst:rest form))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source form)
-                 :file file
-                 :message "Malformed struct field"
-                 :primary-note "expected field type")))
+           :location (cst:source form)
+           :message "Malformed struct field"
+           :primary-note "expected field type"))
 
   ;; (name ty ...)
   (when (cst:consp (cst:rest (cst:rest form)))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source form)
-                 :file file
-                 :message "Malformed struct field"
-                 :primary-note "unexpected form"
-                 :highlight :end)))
+           :location (util:source-end form)
+           :message "Malformed struct field"
+           :primary-note "unexpected form"))
 
   ;; (5 ty)
   (unless (and (cst:atom (cst:first form))
                (symbolp (cst:raw (cst:first form))))
     (error 'parse-error
-           :err (coalton-error
-                 :span (cst:source form)
-                 :file file
-                 :message "Malformed struct field"
-                 :primary-note "unexpected form"
-                 :highlight :end)))
+           :location (util:source-end form)
+           :message "Malformed struct field"
+           :primary-note "unexpected form"))
 
   (make-struct-field
    :name (symbol-name (cst:raw (cst:first form)))
-   :type (parse-type (cst:second form) file)
+   :type (parse-type (cst:second form))
    :source (cst:source form)))

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -12,117 +12,138 @@
 
 (in-package #:coalton-impl/reader)
 
-(defvar *coalton-reader-allowed* t
-  "Is the Coalton reader allowed to parse the current input?
-Used to forbid reading while inside quasiquoted forms.")
-
 (defvar *source-plist* nil)
 
 (defun make-source-file ()
   (destructuring-bind (&key emacs-filename emacs-position &allow-other-keys) *source-plist*
     (if emacs-filename
-        (error:make-coalton-ide-file *compile-file-truename*
-                                     emacs-filename
-                                     emacs-position)
-        (error:make-coalton-file *compile-file-truename*))))
+        (source-error:make-displaced-source-file *compile-file-truename*
+                                                 emacs-filename
+                                                 emacs-position)
+        (source-error:make-source-file *compile-file-truename*))))
 
-(defun read-coalton-toplevel-open-paren (stream char)
+(defun std-macro-char (c)
+  (get-macro-character c (named-readtables:ensure-readtable :standard)))
+
+(defvar *coalton-reader-allowed* t
+  "Is the Coalton reader allowed to parse the current input?
+Used to forbid reading while inside quasiquoted forms.")
+
+(defun %coalton-toplevel (stream)
+  (multiple-value-bind (program env)
+      (entry:entry-point (parser:read-program stream :mode :toplevel-macro))
+    (setf entry:*global-environment* env)
+    program))
+
+(defun %coalton-codegen (stream)
+  (let ((settings:*coalton-skip-update* t)
+        (settings:*emit-type-annotations* nil))
+    (multiple-value-bind (program env)
+        (entry:entry-point (parser:read-program stream :mode :toplevel-macro))
+      (declare (ignore env))
+      `',program)))
+
+(defun %coalton-codegen-ast (stream)
+  (let ((settings:*coalton-skip-update* t)
+        (settings:*emit-type-annotations* nil)
+        (settings:*coalton-dump-ast* t))
+    (multiple-value-bind (program env)
+        (entry:entry-point (parser:read-program stream :mode :toplevel-macro))
+      (declare (ignore program env))
+      nil)))
+
+(defun %coalton-expression (stream)
+  (entry:expression-entry-point (parser:read-expression stream)))
+
+(defun read-open-paren (stream char)
   (unless *coalton-reader-allowed*
-    (return-from read-coalton-toplevel-open-paren
-      (funcall (get-macro-character #\( (named-readtables:ensure-readtable :standard)) stream char)))
+    (return-from read-open-paren
+      (funcall (std-macro-char #\() stream char)))
   (parser:with-reader-context stream
     (let ((first-form
             (multiple-value-bind (form presentp)
                 (parser:maybe-read-form stream)
               (unless presentp
-                (return-from read-coalton-toplevel-open-paren nil))
+                (return-from read-open-paren nil))
               form))
-          (file (make-source-file)))
+          (source-error:*source* (make-source-file)))
       (case (cst:raw first-form)
         (coalton:coalton-toplevel
-          (multiple-value-bind (program env)
-              (entry:entry-point (parser:read-program stream file :mode :toplevel-macro))
-            (setf entry:*global-environment* env)
-            program))
+          (%coalton-toplevel stream))
         (coalton:coalton-codegen
-          (let ((settings:*coalton-skip-update* t)
-                (settings:*emit-type-annotations* nil))
-            (multiple-value-bind (program env)
-                (entry:entry-point (parser:read-program stream file :mode :toplevel-macro))
-              (declare (ignore env))
-              `',program)))
+          (%coalton-codegen stream))
         (coalton:coalton-codegen-ast
-          (let ((settings:*coalton-skip-update* t)
-                (settings:*emit-type-annotations* nil)
-                (settings:*coalton-dump-ast* t))
-            (multiple-value-bind (program env)
-                (entry:entry-point (parser:read-program stream file :mode :toplevel-macro))
-              (declare (ignore program env))
-              nil)))
+          (%coalton-codegen-ast stream))
         (coalton:coalton
-         (entry:expression-entry-point (parser:read-expression stream file) file))
+          (%coalton-expression stream))
         ;; Fall back to reading the list manually
         (t
-         (let ((collected-forms (list (cst:raw first-form)))
-               (dotted-context nil))
-           (loop :do
-             (handler-case
-                 (multiple-value-bind (form presentp)
-                     (parser:maybe-read-form stream)
+         (%coalton-forms stream first-form))))))
 
-                   (cond
-                     ((and (not presentp)
-                           dotted-context)
-                      (error "Invalid dotted list"))
-
-                     ((not presentp)
-                      (return-from read-coalton-toplevel-open-paren
-                        (nreverse collected-forms)))
-
-                     (dotted-context
-                      (when (nth-value 1 (parser:maybe-read-form stream))
-                        (error "Invalid dotted list"))
-                      (return-from read-coalton-toplevel-open-paren
-                        (nreconc collected-forms (cst:raw form))))
-
-                     (t
-                      (push (cst:raw form) collected-forms))))
-               (eclector.reader:invalid-context-for-consing-dot (c)
-                 (when dotted-context
+(defun %coalton-forms (stream first-form)
+  (let ((collected-forms (list (cst:raw first-form)))
+        (dotted-context nil))
+    (loop :do
+      (handler-case
+          (multiple-value-bind (form presentp)
+              (parser:maybe-read-form stream)
+            (cond ((and (not presentp)
+                        dotted-context)
                    (error "Invalid dotted list"))
-                 (setf dotted-context t)
-                 (eclector.reader:recover c))))))))))
+
+                  ((not presentp)
+                   (return-from %coalton-forms
+                     (nreverse collected-forms)))
+
+                  (dotted-context
+                   (when (nth-value 1 (parser:maybe-read-form stream))
+                     (error "Invalid dotted list"))
+                   (return-from %coalton-forms
+                     (nreconc collected-forms (cst:raw form))))
+
+                  (t
+                   (push (cst:raw form) collected-forms))))
+        (eclector.reader:invalid-context-for-consing-dot (c)
+          (when dotted-context
+            (error "Invalid dotted list"))
+          (setf dotted-context t)
+          (eclector.reader:recover c))))))
+
+(defun read-backtick (s c)
+  (let ((*coalton-reader-allowed* nil))
+    (funcall (std-macro-char #\`) s c)))
+
+(defun read-comma (s c)
+  (let ((*coalton-reader-allowed* t))
+    (funcall (std-macro-char #\,) s c)))
 
 (named-readtables:defreadtable coalton:coalton
   (:merge :standard)
-  (:macro-char #\( 'read-coalton-toplevel-open-paren)
-  (:macro-char #\` (lambda (s c)
-                     (let ((*coalton-reader-allowed* nil))
-                       (funcall (get-macro-character #\` (named-readtables:ensure-readtable :standard)) s c))))
-  (:macro-char #\, (lambda (s c)
-                     (let ((*coalton-reader-allowed* t))
-                       (funcall (get-macro-character #\, (named-readtables:ensure-readtable :standard)) s c)))))
+  (:macro-char #\( 'read-open-paren)
+  (:macro-char #\` 'read-backtick)
+  (:macro-char #\, 'read-comma))
+
+(defun process-forms (forms)
+  (let ((*readtable* (named-readtables:ensure-readtable 'coalton:coalton))
+        (*print-circle* t)
+        (source-string (cl:format cl:nil "~S" forms)))
+    (source-error:with-source-string (stream source-string)
+      (cl:read stream))))
 
 (defmacro coalton:coalton-toplevel (&body forms)
-  (let ((*readtable* (named-readtables:ensure-readtable 'coalton:coalton))
-        (*print-circle* t))
-    (with-input-from-string (stream (cl:format cl:nil "~S" (cons 'coalton:coalton-toplevel forms)))
-      (cl:read stream))))
+  (process-forms (cons 'coalton:coalton-toplevel forms)))
 
 (defmacro coalton:coalton-codegen (&body forms)
-  (let ((*readtable* (named-readtables:ensure-readtable 'coalton:coalton))
-        (*print-circle* t))
-    (with-input-from-string (stream (cl:format cl:nil "~S" (cons 'coalton:coalton-codegen forms)))
-      (cl:read stream))))
+  (process-forms (cons 'coalton:coalton-codegen forms)))
 
 (defmacro coalton:coalton-codegen-ast (&body forms)
   (let ((*readtable* (named-readtables:ensure-readtable 'coalton:coalton))
         (*print-circle* t))
-    (with-input-from-string (stream (cl:format cl:nil "~S" (cons 'coalton:coalton-codegen-ast forms)))
+    (source-error:with-source-string (stream (cl:format cl:nil "~S" (cons 'coalton:coalton-codegen-ast forms)))
       (cl:read stream))))
 
 (defmacro coalton:coalton (&rest forms)
   (let ((*readtable* (named-readtables:ensure-readtable 'coalton:coalton))
         (*print-circle* t))
-    (with-input-from-string (stream (cl:format cl:nil "~S" (cons 'coalton:coalton forms)))
+    (source-error:with-source-string (stream (cl:format cl:nil "~S" (cons 'coalton:coalton forms)))
       (cl:read stream))))

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -16,160 +16,51 @@
   "Is the Coalton reader allowed to parse the current input?
 Used to forbid reading while inside quasiquoted forms.")
 
-(defun read-coalton-toplevel-open-paren (stream char)
-  (declare (optimize (debug 2)))
+(defvar *source-plist* nil)
 
+(defun make-source-file ()
+  (destructuring-bind (&key emacs-filename emacs-position &allow-other-keys) *source-plist*
+    (if emacs-filename
+        (error:make-coalton-ide-file *compile-file-truename*
+                                     emacs-filename
+                                     emacs-position)
+        (error:make-coalton-file *compile-file-truename*))))
+
+(defun read-coalton-toplevel-open-paren (stream char)
   (unless *coalton-reader-allowed*
     (return-from read-coalton-toplevel-open-paren
       (funcall (get-macro-character #\( (named-readtables:ensure-readtable :standard)) stream char)))
-
   (parser:with-reader-context stream
     (let ((first-form
             (multiple-value-bind (form presentp)
                 (parser:maybe-read-form stream)
               (unless presentp
-                (return-from read-coalton-toplevel-open-paren
-                  nil))
-              form)))
+                (return-from read-coalton-toplevel-open-paren nil))
+              form))
+          (file (make-source-file)))
       (case (cst:raw first-form)
         (coalton:coalton-toplevel
-          (let ((opened-streams nil))
-            (unwind-protect
-                 (let* ((pathname (or *compile-file-truename* *load-truename*))
-                        (filename (if pathname (namestring pathname) "<unknown>"))
-
-                        (file-input-stream
-                          (cond
-                            ((or #+sbcl (sb-int:form-tracking-stream-p stream)
-                                 nil)
-                             (let ((s (open (pathname stream))))
-                               (push s opened-streams)
-                               s))
-                            (t
-                             stream)))
-                        (file (error:make-coalton-file :stream file-input-stream :name filename)))
-
-                   (handler-bind
-                       ;; Render errors and set highlights
-                       ((error:coalton-base-error
-                          (lambda (c)
-                            (set-highlight-position-for-error stream (funcall (error:coalton-error-err c)))
-                            (error:render-coalton-error c)))
-                        (error:coalton-base-warning
-                          (lambda (c)
-                            (error:render-coalton-warning c))))
-                     (multiple-value-bind (program env)
-                         (entry:entry-point (parser:read-program stream file :mode :toplevel-macro))
-                       (setf entry:*global-environment* env)
-                       program)))
-              ;; Clean up any opened file streams
-              (dolist (s opened-streams)
-                (close s)))))
-
+          (multiple-value-bind (program env)
+              (entry:entry-point (parser:read-program stream file :mode :toplevel-macro))
+            (setf entry:*global-environment* env)
+            program))
         (coalton:coalton-codegen
-          (let ((opened-streams nil))
-            (unwind-protect
-                 (let* ((pathname (or *compile-file-truename* *load-truename*))
-                        (filename (if pathname (namestring pathname) "<unknown>"))
-
-                        (file-input-stream
-                          (cond
-                            ((or #+sbcl (sb-int:form-tracking-stream-p stream)
-                                 nil)
-                             (let ((s (open (pathname stream))))
-                               (push s opened-streams)
-                               s))
-                            (t
-                             stream)))
-                        (file (error:make-coalton-file :stream file-input-stream :name filename)))
-
-                   (handler-bind
-                       ;; Render errors and set highlights
-                       ((error:coalton-base-error
-                          (lambda (c)
-                            (set-highlight-position-for-error stream (funcall (error:coalton-error-err c)))
-                            (error:render-coalton-error c)))
-                        (error:coalton-base-warning
-                          (lambda (c)
-                            (error:render-coalton-warning c))))
-                     (let ((settings:*coalton-skip-update* t)
-                           (settings:*emit-type-annotations* nil))
-                       (multiple-value-bind (program env)
-                           (entry:entry-point (parser:read-program stream file :mode :toplevel-macro))
-                         (declare (ignore env))
-                         `',program))))
-              ;; Clean up any opened file streams
-              (dolist (s opened-streams)
-                (close s)))))
-
+          (let ((settings:*coalton-skip-update* t)
+                (settings:*emit-type-annotations* nil))
+            (multiple-value-bind (program env)
+                (entry:entry-point (parser:read-program stream file :mode :toplevel-macro))
+              (declare (ignore env))
+              `',program)))
         (coalton:coalton-codegen-ast
-          (let ((opened-streams nil))
-            (unwind-protect
-                 (let* ((pathname (or *compile-file-truename* *load-truename*))
-                        (filename (if pathname (namestring pathname) "<unknown>"))
-
-                        (file-input-stream
-                          (cond
-                            ((or #+sbcl (sb-int:form-tracking-stream-p stream)
-                                 nil)
-                             (let ((s (open (pathname stream))))
-                               (push s opened-streams)
-                               s))
-                            (t
-                             stream)))
-                        (file (error:make-coalton-file :stream file-input-stream :name filename)))
-
-                   (handler-bind
-                       ;; Render errors and set highlights
-                       ((error:coalton-base-error
-                          (lambda (c)
-                            (set-highlight-position-for-error stream (funcall (error:coalton-error-err c)))
-                            (error:render-coalton-error c)))
-                        (error:coalton-base-warning
-                          (lambda (c)
-                            (error:render-coalton-warning c))))
-                     (let ((settings:*coalton-skip-update* t)
-                           (settings:*emit-type-annotations* nil)
-                           (settings:*coalton-dump-ast* t))
-                       (multiple-value-bind (program env)
-                           (entry:entry-point (parser:read-program stream file :mode :toplevel-macro))
-                         (declare (ignore program env))
-                         nil))))
-              ;; Clean up any opened file streams
-              (dolist (s opened-streams)
-                (close s)))))
-
+          (let ((settings:*coalton-skip-update* t)
+                (settings:*emit-type-annotations* nil)
+                (settings:*coalton-dump-ast* t))
+            (multiple-value-bind (program env)
+                (entry:entry-point (parser:read-program stream file :mode :toplevel-macro))
+              (declare (ignore program env))
+              nil)))
         (coalton:coalton
-         (let ((opened-streams nil))
-           (unwind-protect
-                (let* ((pathname (or *compile-file-truename* *load-truename*))
-                       (filename (if pathname (namestring pathname) "<unknown>"))
-
-                       (file-input-stream
-                         (cond
-                           ((or #+sbcl (sb-int:form-tracking-stream-p stream)
-                                nil)
-                            (let ((s (open (pathname stream))))
-                              (push s opened-streams)
-                              s))
-                           (t
-                            stream)))
-                       (file (error:make-coalton-file :stream file-input-stream :name filename)))
-
-                  (handler-bind
-                      ;; Render errors and set highlights
-                      ((error:coalton-base-error
-                         (lambda (c)
-                           (set-highlight-position-for-error stream (funcall (error:coalton-error-err c)))
-                           (error:render-coalton-error c)))
-                       (error:coalton-base-warning
-                         (lambda (c)
-                           (error:render-coalton-warning c))))
-                    (entry:expression-entry-point (parser:read-expression stream file) file)))
-             ;; Clean up any opened file streams
-             (dolist (s opened-streams)
-               (close s)))))
-
+         (entry:expression-entry-point (parser:read-expression stream file) file))
         ;; Fall back to reading the list manually
         (t
          (let ((collected-forms (list (cst:raw first-form)))
@@ -191,7 +82,6 @@ Used to forbid reading while inside quasiquoted forms.")
                      (dotted-context
                       (when (nth-value 1 (parser:maybe-read-form stream))
                         (error "Invalid dotted list"))
-
                       (return-from read-coalton-toplevel-open-paren
                         (nreconc collected-forms (cst:raw form))))
 
@@ -202,33 +92,6 @@ Used to forbid reading while inside quasiquoted forms.")
                    (error "Invalid dotted list"))
                  (setf dotted-context t)
                  (eclector.reader:recover c))))))))))
-
-(defun set-highlight-position-for-error (stream error)
-  "Set the highlight position within the editor using implementation specific magic."
-  #+sbcl
-  ;; We need some way of setting FILE-POSITION so that
-  ;; when Slime grabs the location of the error it
-  ;; highlights the correct form.
-  ;;
-  ;; In SBCL, we can't unread more than ~512
-  ;; characters due to limitations with ANSI streams,
-  ;; which breaks our old method of unreading
-  ;; characters until the file position is
-  ;; correct. Instead, we now patch in our own
-  ;; version of FILE-POSITION.
-  ;;
-  ;; This is a massive hack and might start breaking
-  ;; with future changes in SBCL.
-  (when (typep stream 'sb-impl::form-tracking-stream)
-    (let* ((file-offset
-             (- (sb-impl::fd-stream-get-file-position stream)
-                (file-position stream)))
-           (loc (error:coalton-error-location error)))
-      (setf (sb-impl::fd-stream-misc stream)
-            (lambda (stream operation arg1)
-              (if (= (sb-impl::%stream-opcode :get-file-position) operation)
-                  (+ file-offset loc 1)
-                  (sb-impl::tracking-stream-misc stream operation arg1)))))))
 
 (named-readtables:defreadtable coalton:coalton
   (:merge :standard)
@@ -242,32 +105,24 @@ Used to forbid reading while inside quasiquoted forms.")
 
 (defmacro coalton:coalton-toplevel (&body forms)
   (let ((*readtable* (named-readtables:ensure-readtable 'coalton:coalton))
-        (*compile-file-truename*
-          (pathname (format nil "COALTON-TOPLEVEL (~A)" *compile-file-truename*)))
         (*print-circle* t))
     (with-input-from-string (stream (cl:format cl:nil "~S" (cons 'coalton:coalton-toplevel forms)))
       (cl:read stream))))
 
 (defmacro coalton:coalton-codegen (&body forms)
   (let ((*readtable* (named-readtables:ensure-readtable 'coalton:coalton))
-        (*compile-file-truename*
-          (pathname (format nil "COALTON-TOPLEVEL (~A)" *compile-file-truename*)))
         (*print-circle* t))
     (with-input-from-string (stream (cl:format cl:nil "~S" (cons 'coalton:coalton-codegen forms)))
       (cl:read stream))))
 
 (defmacro coalton:coalton-codegen-ast (&body forms)
   (let ((*readtable* (named-readtables:ensure-readtable 'coalton:coalton))
-        (*compile-file-truename*
-          (pathname (format nil "COALTON-TOPLEVEL (~A)" *compile-file-truename*)))
         (*print-circle* t))
     (with-input-from-string (stream (cl:format cl:nil "~S" (cons 'coalton:coalton-codegen-ast forms)))
       (cl:read stream))))
 
 (defmacro coalton:coalton (&rest forms)
   (let ((*readtable* (named-readtables:ensure-readtable 'coalton:coalton))
-        (*compile-file-truename*
-          (pathname (format nil "COALTON (~A)" *compile-file-truename*)))
         (*print-circle* t))
     (with-input-from-string (stream (cl:format cl:nil "~S" (cons 'coalton:coalton forms)))
       (cl:read stream))))

--- a/src/source-error.lisp
+++ b/src/source-error.lisp
@@ -1,0 +1,514 @@
+(defpackage #:source-error
+  (:use
+   #:cl)
+  (:export
+   #:context
+   #:deferred-note
+   #:help
+   #:note
+   #:print-source-error                 ; FUNCTION
+   #:source-error                       ; FUNCTION, CONDITION
+   #:source-location                    ; FUNCTION
+   #:source-name                        ; GENERIC
+   #:source-stream                      ; GENERIC
+   #:source-warning))                   ; FUNCTION
+
+(in-package #:source-error)
+
+;; Source-aware error and warning condition types and helper functions
+;;
+;; These are the condition classes used by applications. Error and
+;; warning conditions both have an `error` slot of type
+;; `%source-error` that contains detailed information about the
+;; source of the error and optional explanatory notes and
+;; messages. `print-source-error` uses this structure to emit an
+;; annotated error description when either of these conditions is
+;; printed.
+
+;; source info protocol
+;;
+;; The generic functions `source-name` and `source-stream` define a
+;; protocol that gives the condition printer access to an input source
+;; related to the condition, via the `source` sl§>ot on a
+;; %source-error struct (see below). These provide, respectively,
+;; the name, and contents of a source.
+
+;; source annotation structures
+;;
+;; These are classes that hold for input span-associated error
+;; annotations. The top-level `%source-error` structure may
+;; contain sets of optional `note` and
+;; `source-error-help` messages that refer to source spans, which
+;; `print-source-error` will resolve to character ranges in an input
+;; source.
+
+(defgeneric source-name (source)
+  (:documentation "Returns a string that names a source, for reporting in conditions. In
+the case of files, this is the filename path."))
+
+(defgeneric source-stream (source)
+  (:documentation "A seekable stream providing access to the original contents of a
+source, for reporting in condition printers. WARNING: it is the
+responsibility of the caller to close the stream, if not using the
+with-source-stream convenience macro."))
+
+(defun report-error (condition stream)
+  (with-slots (error) condition
+    (print-source-error stream error)))
+
+(define-condition source-condition (condition)
+  ((error :initarg :err))
+  (:documentation "The type for user-facing errors.")
+  (:report report-error))
+
+(define-condition source-error (source-condition error)
+  ()
+  (:documentation "The type for user-facing errors."))
+
+(define-condition source-warning (source-condition style-warning)
+  ()
+  (:documentation "The type for user-facing warnings."))
+
+(defclass source-annotation ()
+  ((span :initarg :span
+         :reader span)
+   (message :initarg :message
+            :reader note-message)))
+
+(defun span-start (source-annotation)
+  (car (slot-value source-annotation 'span)))
+
+(defun span-end (source-annotation)
+  (cdr (slot-value source-annotation 'span)))
+
+(defclass note (source-annotation)
+  ((type :initarg :type
+         :reader note-type)))
+
+(defun note (&key span type message)
+  (make-instance 'note
+    :span span
+    :message message
+    :type type))
+
+(defclass help (source-annotation)
+  ((replacement :initarg :replacement
+                :reader note-replacement)))
+
+(defun help (&key span replacement message)
+  (make-instance 'help
+    :span span
+    :message message
+    :replacement replacement))
+
+(defclass deferred-note ()
+  ((fn :initarg :fn)
+   (rendered)))
+
+(defun deferred-note (fn)
+  (make-instance 'deferred-note :fn fn))
+
+(defclass error-context ()
+  ((message :initarg :message
+            :reader error-context-message)))
+
+(defun context (&key message)
+  (make-instance 'error-context :message message))
+
+(defclass %source-error ()
+  ((type :initarg :type)
+   (source :initarg :source
+           :reader error-source)
+   (location :initarg :location)
+   (message :initarg :message)
+   (notes :initarg :notes
+          :reader notes)
+   (help :initarg :help
+         :initform nil)
+   (context :initarg :context
+            :reader error-context))
+  (:documentation "The content of a source-condition, used to produce a printer-state when the error is printed."))
+
+(defun source-error (&key (type :error) source location message primary-note notes help context)
+  "Construct a %SOURCE-ERROR instance with a message and primary note attached to the provided form.
+
+MESSAGE and PRIMARY-NOTE must be supplied string arguments.
+NOTES and HELP may optionally be supplied notes and help messages."
+  (let ((span (etypecase location
+                (cons location)
+                (integer (cons (1- location) location)))))
+    (make-instance '%source-error
+      :type type
+      :source source
+      :location (etypecase location
+                  (cons (car location))
+                  (integer location))
+      :message message
+      :notes (list* (note :type :primary
+                          :span span
+                          :message primary-note)
+                    notes)
+      :help help
+      :context context)))
+
+(defmacro with-source-stream ((stream source-error) &body body)
+  `(with-open-stream (,stream (source-stream (error-source ,source-error)))
+    ,@body))
+
+;; error formatter
+;;
+;; `print-source-error`, at the bottom, is a workhorse function that
+;; takes a %source-error structure, resolves source-relative spans
+;; to the input source, and then prints annotated source code.
+;;
+;; `printer-state` maintains state during printing: current line,
+;; note depth, etc.
+
+(defclass printer-state ()
+  ((source-stream :initarg :source-stream
+                  :reader source-stream
+                  :documentation "The stream form which source code is to be read.")
+
+   (notes :initarg :notes)
+   (help :initarg :help)
+   (context :initarg :context)
+
+   (line-offsets :reader line-offsets)
+   (offset-positions :initform (make-hash-table))
+
+   (line-number-width)
+   (current-line)
+   (last-line)
+
+   ;; We need to keep track of the current depth of multiline
+   ;; notes so that we can pad the left with the correct
+   ;; number of columns.
+
+   (note-stack :accessor note-stack
+               :initform nil)
+   (note-max-depth :initform 0)))
+
+(defun first-line-number (notes offset-positions)
+  (car (gethash (span-start (car notes)) offset-positions)))
+
+(defun last-line-number (notes offset-positions)
+  (let ((last-offset (apply #'max (mapcar #'span-end notes))))
+    (car (gethash last-offset offset-positions))))
+
+(defmethod initialize-instance :after ((printer-state printer-state) &rest initargs)
+  (declare (ignore initargs))
+  (with-slots (source-stream
+               line-offsets
+               offset-positions
+               note-max-depth
+               current-line
+               last-line
+               line-number-width
+               notes)
+      printer-state
+    (let ((char-offsets (char-offsets printer-state))
+          (offsets (find-line-offsets source-stream)))
+      (setf line-offsets (make-array (length offsets) :initial-contents offsets))
+      (loop :for (char-offset line column) :in (find-column-offsets offsets char-offsets)
+            :do (setf (gethash char-offset offset-positions)
+                      (cons line column)))
+      (setf current-line (1- (first-line-number notes offset-positions))
+            last-line (last-line-number notes offset-positions)
+            line-number-width (1+ (floor (log last-line 10)))
+            note-max-depth (max-depth notes)))))
+
+(defun span-lines (printer-state source-annotation)
+  "Return the start and end lines of SOURCE-ANNOTATION"
+  (with-slots (offset-positions) printer-state
+    (destructuring-bind (start . end) (span source-annotation)
+      (values (car (gethash start offset-positions))
+              (car (gethash end offset-positions))))))
+
+(defun span-positions (printer-state source-annotation)
+  "Return the start and end positions of SOURCE-ANNOTATION"
+  (with-slots (offset-positions) printer-state
+    (destructuring-bind (start . end) (span source-annotation)
+      (destructuring-bind (start-line . start-column)
+          (gethash start offset-positions)
+        (destructuring-bind (end-line . end-column)
+            (gethash end offset-positions)
+          (values start-line start-column end-line end-column))))))
+
+;; Mapping between character offsets and line and column positions.
+;;
+;; First line (zero indexed) = offset 0, etc.
+
+(defun find-line-offsets (stream)
+  "Compute the offsets of lines in a stream."
+  (file-position stream 0)
+  (loop :with index := 0
+        :for char := (read-char stream nil nil)
+        :unless char
+          :return (cons 0 offsets)
+        :when (char= char #\Newline)
+          :collect (1+ index) :into offsets
+        :do (incf index)))
+
+(defun find-column-offsets (line-offsets offsets)
+  "Given the offsets of newlines in a stream, compute the line and
+column numbers for a sequence of absolute stream offsets."
+  (loop :with line := 0
+        :with position := 0
+        :while offsets
+        :when (or (null line-offsets)
+                  (< (car offsets)
+                     (car line-offsets)))
+          :collect (list (car offsets) line (- (car offsets) position))
+          :and :do (pop offsets)
+        :else
+          :do (setf position (car line-offsets)
+                    line (1+ line)
+                    line-offsets (cdr line-offsets))))
+
+(defun line-contents (printer-state line-number)
+  (with-slots (line-offsets source-stream) printer-state
+    (let ((offset (if (= 1 line-number)
+                      0
+                      (aref line-offsets (1- line-number)))))
+      (file-position source-stream offset)
+      (read-line source-stream nil ""))))
+
+(defun positioned-annotations (printer-state)
+  (with-slots (notes help) printer-state
+    (concatenate 'list notes help)))
+
+(defun char-offsets (printer-state)
+  (sort (remove-duplicates
+         (mapcan (lambda (note)
+                   (list (span-start note) (span-end note)))
+                 (positioned-annotations printer-state)))
+        #'<))
+
+(defun start-position (printer-state span)
+  (with-slots (offset-positions) printer-state
+    (gethash (span-start span) offset-positions)))
+
+(defun start-line (printer-state span)
+  (with-slots (offset-positions) printer-state
+    (car (gethash (span-start span) offset-positions))))
+
+(defun start-column (printer-state span)
+  (with-slots (offset-positions) printer-state
+    (cdr (gethash (span-start span) offset-positions))))
+
+(defun end-position (printer-state span)
+  (with-slots (offset-positions) printer-state
+    (gethash (span-end span) offset-positions)))
+
+(defun end-line (printer-state span)
+  (with-slots (offset-positions) printer-state
+    (car (gethash (span-end span) offset-positions))))
+
+(defun end-column (printer-state span)
+  (with-slots (offset-positions) printer-state
+    (cdr (gethash (span-end span) offset-positions))))
+
+(defun span-point< (a b)
+  (destructuring-bind (offset-a . type-a) a
+    (destructuring-bind (offset-b . type-b) b
+      (if (= offset-a offset-b)
+          (and (eql type-a :start)
+               (eql type-b :end))
+          (< offset-a offset-b)))))
+
+(defun span-points (span)
+  (list (cons (span-start span) :start)
+        (cons (span-end span) :end)))
+
+(defun max-depth (notes)
+  (let ((max-depth 0)
+        (depth 0))
+    (dolist (op (mapcar #'cdr (sort (mapcan #'span-points notes) #'span-point<)) max-depth)
+      (cond ((eql op :start)
+             (incf depth)
+             (when (< max-depth depth)
+               (setf max-depth depth)))
+            ((eql op :end)
+             (decf depth))))))
+
+(defun offset-position (printer-state location)
+  (gethash location (slot-value printer-state 'offset-positions) (cons 1 0)))
+
+(defun note-highlight-char (note)
+  (case (note-type note)
+    (:primary #\^)
+    (otherwise #\-)))
+
+(defun write-char-n (char n stream)
+  (dotimes (n n)
+    (write-char char stream)))
+
+;; Printer
+
+(defun print-error-location (stream printer-state source-error)
+  (with-slots (type source location message) source-error
+    (destructuring-bind (line . column)
+        (offset-position printer-state location)
+      (format stream "~(~A~): ~A~%  --> ~A:~D:~D~%"
+              type
+              message
+              (source-name source)
+              line
+              column))))
+
+(defun print-line-prefix (stream printer-state &key (line-number nil))
+  (with-slots (line-number-width) printer-state
+    (cond (line-number
+           (format stream " ~va |" line-number-width line-number))
+          (t
+           (write-char-n #\Space (+ 2 line-number-width) stream)
+           (write-char #\| stream)))))
+
+(defun print-line-number (stream printer-state line-number show-line-number)
+  (with-slots (line-number-width note-stack) printer-state
+    (print-line-prefix stream printer-state :line-number (and show-line-number line-number))
+    (format stream
+            " ~{~:[ ~;|~]~}"
+            (mapcar
+             (lambda (note)
+               (>= (end-line printer-state note)
+                   line-number))
+             note-stack))))
+
+(defun print-line-contents (stream printer-state line-number)
+  (print-line-number stream printer-state line-number t)
+  (with-slots (note-stack note-max-depth) printer-state
+    (format stream "~v@{ ~}~A~%"
+            (- note-max-depth (length note-stack))
+            (line-contents printer-state line-number))))
+
+(defun print-single-line-note (stream printer-state note)
+  (multiple-value-bind (start-line start-column end-line end-column)
+      (span-positions printer-state note)
+    (declare (ignore end-line))
+    (print-line-number stream printer-state start-line nil)
+    (with-slots (note-max-depth note-stack) printer-state
+      (format stream "~v{~C~:*~}~v{~C~:*~} ~A~%"
+              (+ start-column
+                 (- note-max-depth (length note-stack)))
+              '(#\Space)
+              (- end-column start-column)
+              (list (note-highlight-char note))
+              (note-message note)))))
+
+(defun print-note-start (stream printer-state note)
+  (destructuring-bind (start-line . start-column)
+      (start-position printer-state note)
+    (print-line-number stream printer-state start-line nil)
+    (with-slots (note-max-depth note-stack) printer-state
+      (write-char #\Space stream)
+      (write-char-n #\_ (+ start-column (- note-max-depth (length note-stack) 1)) stream)
+      (write-char (note-highlight-char note) stream)
+      (terpri stream))))
+
+(defun print-note-end (stream printer-state note)
+  (let ((start-line (start-line printer-state note))
+        (end-column (end-column printer-state note)))
+    (print-line-number stream printer-state start-line nil)
+    (with-slots (note-max-depth note-stack) printer-state
+      (write-char-n #\_ (+ end-column (- note-max-depth (length note-stack) 1)) stream)
+      (format stream "~C ~A~%" (note-highlight-char note) (note-message note)))))
+
+(defun print-finished-notes-for-line (stream printer-state line-number)
+  (with-slots (note-stack) printer-state
+    ;; Check if there are any multiline notes that need to be printed
+    (loop :for stack-head := note-stack :then (cdr stack-head)
+          :for note := (car stack-head)
+          :for end-line := (and note (end-line printer-state note))
+          :when (null stack-head)
+            :do (return)
+          :when (= line-number end-line)
+            :do (print-note-end stream printer-state note)
+          :when (and (eq note (car note-stack))
+                     (>= line-number end-line))
+            :do (pop note-stack))))
+
+(defun print-lines-until (stream printer-state line-number)
+  (with-slots (current-line note-stack) printer-state
+    (cond ((= line-number current-line)
+           ;; If we are on the same line then don't reprint.
+           )
+          ((>= 3 (- line-number current-line))
+           ;; If we are within 3 lines of the previous one then just
+           ;; print those lines.
+           (loop :for line :from current-line :below line-number
+                 :do (print-line-contents stream printer-state (1+ line))
+                 :unless (= (1+ line) line-number)
+                   :do (print-finished-notes-for-line stream printer-state (1+ line))))
+          (t
+           ;; Otherwise split the output.
+           (print-line-contents stream printer-state (1+ current-line))
+           ;; Print out any intermediate multiline note endings.
+           (loop :for note :in note-stack
+                 :for end-line := (end-line printer-state note)
+                 :when (< current-line end-line line-number)
+                   :do (print-lines-until stream printer-state end-line))
+           (format stream " ...~%")
+           (print-line-contents stream printer-state (1- line-number))
+           (print-line-contents stream printer-state line-number)))
+    (setf current-line line-number)))
+
+(defun print-note (stream printer-state note)
+  (multiple-value-bind (start-line end-line)
+      (span-lines printer-state note)
+    (print-lines-until stream printer-state start-line)
+    (cond ((/= start-line end-line)
+           (print-note-start stream printer-state note)
+           (push note (note-stack printer-state)))
+          (t
+           (print-single-line-note stream printer-state note)
+           (print-finished-notes-for-line stream printer-state start-line)))))
+
+(defun print-notes (stream printer-state)
+  (with-slots (notes last-line) printer-state
+    (loop :for note :in notes
+          :do (print-note stream printer-state note))
+    (print-lines-until stream printer-state last-line)
+    (print-finished-notes-for-line stream printer-state last-line)))
+
+(defun print-help (stream printer-state help)
+  (with-slots (source-stream) printer-state
+    (multiple-value-bind (start-line start-column end-line end-column)
+        (span-positions printer-state help)
+      (unless (= start-line end-line)
+        (error "multiline help messages not supported"))
+      (format stream "help: ~A~%" (note-message help))
+      (let ((line (line-contents printer-state start-line)))
+        (print-line-prefix stream printer-state :line-number start-line)
+        (format stream " ~A" (subseq line 0 start-column))
+        (let ((replaced-text (funcall (note-replacement help)
+                                      (subseq line start-column end-column))))
+          (format stream "~A~A~%" replaced-text (subseq line end-column))
+          (print-line-prefix stream printer-state)
+          (format stream "~v{~C~:*~}~v{~C~:*~}~%"
+                  (1+ start-column) '(#\Space)
+                  (length replaced-text) '(#\-)))))))
+
+(defun print-empty-line (stream printer-state)
+  (print-line-prefix stream printer-state)
+  (terpri stream))
+
+(defun make-printer-state (source-stream source-error)
+  (with-slots (notes help context) source-error
+    (make-instance 'printer-state
+      :source-stream source-stream
+      :notes (sort notes #'< :key #'span-start)
+      :help help
+      :context context)))
+
+(defun print-source-error (stream source-error)
+  (with-source-stream (source-stream source-error)
+    (let ((state (make-printer-state source-stream source-error)))
+      (print-error-location stream state source-error)
+      (print-empty-line stream state)
+      (with-slots (help context last-line) state
+        (print-notes stream state)
+        (loop :for help :in help
+              :do (print-help stream state help))
+        (loop :for context :in context
+              :do (format stream "note: ~A~%" (error-context-message context)))))))

--- a/src/typechecker/base.lisp
+++ b/src/typechecker/base.lisp
@@ -2,16 +2,14 @@
   (:use
    #:cl)
   (:import-from
-   #:coalton-impl/error
-   #:coalton-file
-   #:coalton-error
-   #:make-coalton-error-note
-   #:make-coalton-error-help)
+   #:source-error
+   #:source-error
+   #:make-note
+   #:make-help)
   (:export
-   #:coalton-file
-   #:coalton-error
-   #:make-coalton-error-note
-   #:make-coalton-error-help)
+   #:source-error
+   #:make-note
+   #:make-help)
   (:local-nicknames
    (#:util #:coalton-impl/util)
    (#:error #:coalton-impl/error)
@@ -24,12 +22,12 @@
 
 (in-package #:coalton-impl/typechecker/base)
 
-(define-condition tc-error (error:coalton-base-error)
+(define-condition tc-error (error:coalton-error)
   ()
   (:report
-   (lambda (c s)
+   (lambda (condition stream)
      (tc:with-pprint-variable-context ()
-       (source-error:print-source-error c s)))))
+       (source-error:report-source-condition condition stream)))))
 
 (defun check-duplicates (elems f g callback)
   "Check for duplicate elements in ELEMS. F maps items in ELEMS to
@@ -58,11 +56,10 @@ source tuples which are compared for ordering."
         :else
           :do (setf (gethash (funcall f elem) table) elem)))
 
-(defun check-package (elems f source file)
+(defun check-package (elems f source)
   (declare (type list elems)
            (type function f)
-           (type function source)
-           (type coalton-file file))
+           (type function source))
 
   (loop :for elem :in elems
         :for id := (funcall f elem)
@@ -71,12 +68,10 @@ source tuples which are compared for ordering."
 
         :unless (equalp (symbol-package id) *package*)
           :do (error 'tc-error
-                     :err (coalton-error
-                           :span (funcall source elem)
-                           :file file
-                           :message "Invalid identifier name"
-                           :primary-note (format nil "The symbol ~S is defined in the package ~A and not the current package ~A"
-                                            id
-                                            (symbol-package id)
-                                            *package*)))))
+                     :location (funcall source elem)
+                     :message "Invalid identifier name"
+                     :primary-note (format nil "The symbol ~S is defined in the package ~A and not the current package ~A"
+                                           id
+                                           (symbol-package id)
+                                           *package*))))
 

--- a/src/typechecker/base.lisp
+++ b/src/typechecker/base.lisp
@@ -28,10 +28,8 @@
   ()
   (:report
    (lambda (c s)
-     (if (error:coalton-error-text c)
-         (write-string (error:coalton-error-text c) s)
-         (tc:with-pprint-variable-context ()
-           (error:display-coalton-error s (error:coalton-error-err c)))))))
+     (tc:with-pprint-variable-context ()
+       (source-error:print-source-error c s)))))
 
 (defun check-duplicates (elems f g callback)
   "Check for duplicate elements in ELEMS. F maps items in ELEMS to

--- a/src/typechecker/define-class.lisp
+++ b/src/typechecker/define-class.lisp
@@ -37,9 +37,8 @@
 ;;; Entrypoint
 ;;;
 
-(defun toplevel-define-class (classes file env)
+(defun toplevel-define-class (classes env)
   (declare (type parser:toplevel-define-class-list classes)
-           (type error:coalton-file file)
            (type tc:environment env)
            (values tc:ty-class-list tc:environment))
 
@@ -47,15 +46,13 @@
   (check-package
    classes
    (alexandria:compose #'parser:identifier-src-name #'parser:toplevel-define-class-name)
-   #'parser:toplevel-define-class-head-src
-   file)
+   #'parser:toplevel-define-class-head-src)
 
   ;; Check that all methods are in the current package
   (check-package
    (mapcan (alexandria:compose #'copy-list #'parser:toplevel-define-class-methods) classes)
    (alexandria:compose #'parser:identifier-src-name #'parser:method-definition-name)
-   #'parser:method-definition-source
-   file)
+   #'parser:method-definition-source)
 
   ;; Check for duplicate class definitions
   (check-duplicates
@@ -64,17 +61,16 @@
    #'parser:toplevel-define-class-source
    (lambda (first second)
      (error 'tc-error
-            :err (coalton-error
-                  :span (parser:toplevel-define-class-head-src first)
-                  :file file
-                  :message "Duplicate class definition"
-                  :primary-note "first definition here"
-                  :notes
-                  (list
-                   (make-coalton-error-note
-                    :type :primary
-                    :span (parser:toplevel-define-class-head-src second)
-                    :message "second definition here"))))))
+            :location (parser:toplevel-define-class-head-src first)
+            
+            :message "Duplicate class definition"
+            :primary-note "first definition here"
+            :notes
+            (list
+             (source-error:make-note
+              :type :primary
+              :location (parser:toplevel-define-class-head-src second)
+              :message "second definition here")))))
 
   ;; Check for duplicate method definitions
   (check-duplicates
@@ -83,17 +79,16 @@
    #'parser:method-definition-source
    (lambda (first second)
      (error 'tc-error
-            :err (coalton-error
-                  :span (parser:method-definition-source first)
-                  :file file
-                  :message "Duplicate method definition"
-                  :primary-note "first definition here"
-                  :notes
-                  (list
-                   (make-coalton-error-note
-                    :type :primary
-                    :span (parser:method-definition-source second)
-                    :message "second definition here"))))))
+            :location (parser:method-definition-source first)
+            
+            :message "Duplicate method definition"
+            :primary-note "first definition here"
+            :notes
+            (list
+             (source-error:make-note
+              :type :primary
+              :location (parser:method-definition-source second)
+              :message "second definition here")))))
 
   (loop :for class :in classes :do
     ;; Classes cannot have duplicate variables
@@ -103,17 +98,16 @@
      #'parser:keyword-src-source
      (lambda (first second)
        (error 'tc-error
-              :err (coalton-error
-                    :span (parser:keyword-src-source first)
-                    :file file
-                    :message "Duplicate class variable"
-                    :primary-note "first usage here"
-                    :notes
-                    (list
-                     (make-coalton-error-note
-                      :type :primary
-                      :span (parser:keyword-src-source second)
-                      :message "second usage here")))))))
+              :location (parser:keyword-src-source first)
+              
+              :message "Duplicate class variable"
+              :primary-note "first usage here"
+              :notes
+              (list
+               (source-error:make-note
+                :type :primary
+                :location (parser:keyword-src-source second)
+                :message "second usage here"))))))
 
   (let* ((class-table
            (loop :with table := (make-hash-table :test #'eq)
@@ -164,27 +158,25 @@
            ;; Classes cannot have cyclic superclasses
            :when (intersection superclass-names scc-names :test #'eq)
              :do (error 'tc-error
-                        :err (coalton-error
-                              :span (parser:toplevel-define-class-head-src (first scc))
-                              :file file
-                              :message "Cyclic superclasses"
-                              :primary-note "in class defined here"
-                              :notes (loop :for class :in (rest scc)
-                                           :collect (make-coalton-error-note
-                                                     :type :primary
-                                                     :span (parser:toplevel-define-class-head-src class)
-                                                     :message "in class defined here"))))
+                        :location (parser:toplevel-define-class-head-src (first scc))
+                        
+                        :message "Cyclic superclasses"
+                        :primary-note "in class defined here"
+                        :notes (loop :for class :in (rest scc)
+                                     :collect (source-error:make-note
+                                               :type :primary
+                                               :location (parser:toplevel-define-class-head-src class)
+                                               :message "in class defined here")))
 
            :append (multiple-value-bind (classes env_)
-                       (infer-class-scc-kinds scc env file)
+                       (infer-class-scc-kinds scc env)
                      (setf env env_)
                      classes))
      env)))
 
-(defun infer-class-scc-kinds (classes env file)
+(defun infer-class-scc-kinds (classes env)
   (declare (type parser:toplevel-define-class-list classes)
            (type tc:environment env)
-           (type error:coalton-file file)
            (values tc:ty-class-list tc:environment))
 
   (let* ((renamed-classes (parser:rename-type-variables classes))
@@ -196,7 +188,7 @@
            (loop :for class :in renamed-classes
 
                  :for class-name := (parser:identifier-src-name (parser:toplevel-define-class-name class))
-          
+                 
                  :for vars := (mapcar #'parser:keyword-src-name
                                       (parser:toplevel-define-class-vars class))
 
@@ -216,7 +208,7 @@
          (partial-classes
            (loop :for class :in renamed-classes
                  :collect (multiple-value-bind (partial-class ksubs_)
-                              (infer-class-kinds class partial-env ksubs file)
+                              (infer-class-kinds class partial-env ksubs)
                             (setf ksubs ksubs_)
                             partial-class))))
 
@@ -318,11 +310,10 @@
                                               fundeps))) 
              :do (progn
                    (error 'tc-error
-                          :err (coalton-error
-                                :span (parser:toplevel-define-class-head-src class)
-                                :file file
-                                :message "Invalid fundep redefinition"
-                                :primary-note (format nil "unable to redefine the fudndeps of class ~S." class-name))))
+                          :location (parser:toplevel-define-class-head-src class)
+                          
+                          :message "Invalid fundep redefinition"
+                          :primary-note (format nil "unable to redefine the fudndeps of class ~S." class-name)))
 
            :when fundeps
              :do (setf env (tc:initialize-fundep-environment env class-name))
@@ -366,11 +357,10 @@
      env)))
 
 
-(defun infer-class-kinds (class env ksubs file)
+(defun infer-class-kinds (class env ksubs)
   (declare (type parser:toplevel-define-class class)
            (type partial-type-env env)
            (type tc:ksubstitution-list ksubs)
-           (type error:coalton-file file)
            (values partial-class tc:ksubstitution-list))
 
   (let ((var-names (mapcar #'parser:keyword-src-name (parser:toplevel-define-class-vars class))))
@@ -383,17 +373,16 @@
                 #'parser:keyword-src-source
                 (lambda (first second)
                   (error 'tc-error
-                         :err (coalton-error
-                               :span (parser:keyword-src-source first)
-                               :file file
-                               :message "Duplicate variable in function dependency"
-                               :primary-note "first usage here"
-                               :notes
-                               (list
-                                (make-coalton-error-note
-                                 :type :primary
-                                 :span (parser:keyword-src-source second)
-                                 :message "second usage here"))))))))
+                         :location (parser:keyword-src-source first)
+                         
+                         :message "Duplicate variable in function dependency"
+                         :primary-note "first usage here"
+                         :notes
+                         (list
+                          (source-error:make-note
+                           :type :primary
+                           :location (parser:keyword-src-source second)
+                           :message "second usage here")))))))
       (loop :for fundep :in (parser:toplevel-define-class-fundeps class)
             :do (check-duplicate-fundep-variables (parser:fundep-left fundep))
             :do (check-duplicate-fundep-variables (parser:fundep-right fundep))))
@@ -403,12 +392,11 @@
                (loop :for var :in vars
                      :unless (find (parser:keyword-src-name var) var-names :test #'eq)
                        :do (error 'tc-error
-                                  :err (coalton-error
-                                        :span (parser:keyword-src-source var)
-                                        :file file
-                                        :message "Unkown type variable"
-                                        :primary-note (format nil "unknown type variable ~S"
-                                                              (parser:keyword-src-name var)))))))
+                                  :location (parser:keyword-src-source var)
+                                  
+                                  :message "Unkown type variable"
+                                  :primary-note (format nil "unknown type variable ~S"
+                                                        (parser:keyword-src-name var))))))
       (loop :for fundep :in (parser:toplevel-define-class-fundeps class)
             :do (check-fundep-variables (parser:fundep-left fundep))
             :do (check-fundep-variables (parser:fundep-right fundep))))
@@ -425,7 +413,7 @@
            (preds
              (loop :for pred :in (parser:toplevel-define-class-preds class)
                    :collect (multiple-value-bind (pred ksubs_)
-                                (infer-predicate-kinds pred ksubs env file)
+                                (infer-predicate-kinds pred ksubs env)
                               (setf ksubs ksubs_)
                               pred)))
            
@@ -446,11 +434,10 @@
                    ;; Ensure that methods are not ambiguous
                    :unless (subsetp var-names (tc:closure tyvars fundeps) :test #'eq)
                      :do (error 'tc-error
-                                :err (coalton-error
-                                      :span (parser:method-definition-source method)
-                                      :file file
-                                      :message "Amgigious method"
-                                      :primary-note "the method is ambiguous"))
+                                :location (parser:method-definition-source method)
+                                
+                                :message "Amgigious method"
+                                :primary-note "the method is ambiguous")
 
                          ;; Ensure that the type variables in each
                          ;; pred are not a subset of the class
@@ -462,17 +449,16 @@
 
                              :when (subsetp tyvars var-names)
                                :do (error 'tc-error
-                                          :err (coalton-error
-                                                :span (parser:ty-predicate-source pred)
-                                                :file file
-                                                :message "Invalid method predicate"
-                                                :primary-note "method predicate contains only class variables")))
-                      
+                                          :location (parser:ty-predicate-source pred)
+                                          
+                                          :message "Invalid method predicate"
+                                          :primary-note "method predicate contains only class variables"))
+                       
                    :do (loop :for tyvar :in new-tyvars
                              :do (partial-type-env-add-var env tyvar))
 
                    :collect (multiple-value-bind (ty ksubs_)
-                                (infer-type-kinds ty tc:+kstar+ ksubs env file)
+                                (infer-type-kinds ty tc:+kstar+ ksubs env)
                               (setf ksubs ksubs_)
                               ty))))
 

--- a/src/typechecker/define-instance.lisp
+++ b/src/typechecker/define-instance.lisp
@@ -27,40 +27,40 @@
 
 (in-package #:coalton-impl/typechecker/define-instance)
 
-(defun toplevel-define-instance (instances env file)
+(defun toplevel-define-instance (instances env)
   (declare (type parser:toplevel-define-instance-list instances)
            (type tc:environment env)
-           (type coalton-file file)
+           
            (values tc:ty-class-instance-list tc:environment))
 
   (values
    (loop :for instance :in instances
          :collect (multiple-value-bind (instance env_)
-                      (define-instance-in-environment instance env file)
+                      (define-instance-in-environment instance env)
                     (setf env env_)
                     instance))
 
    env))
 
-(defun toplevel-typecheck-instance (instances unparsed-instances env file)
+(defun toplevel-typecheck-instance (instances unparsed-instances env)
   (declare (type tc:ty-class-instance-list instances)
            (type parser:toplevel-define-instance-list unparsed-instances)
            (type tc:environment env)
-           (type coalton-file file)
+           
            (values toplevel-define-instance-list))
 
   (loop :for instance :in instances
         :for unparsed-instance :in unparsed-instances
-        :collect (typecheck-instance instance unparsed-instance env file)))
+        :collect (typecheck-instance instance unparsed-instance env)))
 
-(defun define-instance-in-environment (instance env file)
+(defun define-instance-in-environment (instance env)
   (declare (type parser:toplevel-define-instance instance)
            (type tc:environment env)
-           (type coalton-file file)
+           
            (values tc:ty-class-instance tc:environment))
 
-  (check-for-orphan-instance instance file)
-  (check-instance-valid instance file)
+  (check-for-orphan-instance instance)
+  (check-instance-valid instance)
 
   (let* ((unparsed-pred (parser:toplevel-define-instance-pred instance))
 
@@ -75,13 +75,13 @@
     (let* ((ksubs nil)
 
            (pred (multiple-value-bind (pred ksubs_)
-                     (infer-predicate-kinds unparsed-pred ksubs partial-env file)
+                     (infer-predicate-kinds unparsed-pred ksubs partial-env)
                    (setf ksubs ksubs_)
                    pred))
 
            (context (loop :for pred :in unparsed-context
                           :collect (multiple-value-bind (pred ksubs_)
-                                       (infer-predicate-kinds pred ksubs partial-env file)
+                                       (infer-predicate-kinds pred ksubs partial-env)
                                      (setf ksubs ksubs_)
                                      pred)))
 
@@ -138,23 +138,21 @@
               (setf env (tc:update-instance-fundeps env pred))
             (tc:fundep-conflict (e)
               (error 'tc-error
-                     :err (coalton-error
-                           :span (parser:toplevel-define-instance-head-src instance)
-                           :file file
-                           :message "Instance fundep conflict"
-                           :primary-note (let ((*print-escape* nil))
-                                           (with-output-to-string (s)
-                                             (print-object e s))))))))
+                     :location (parser:toplevel-define-instance-head-src instance)
+                     
+                     :message "Instance fundep conflict"
+                     :primary-note (let ((*print-escape* nil))
+                                     (with-output-to-string (s)
+                                       (print-object e s)))))))
 
         (handler-case
             (setf env (tc:add-instance env class-name instance-entry))
           (tc:overlapping-instance-error (e)
             (error 'tc-error
-                   :err (coalton-error
-                         :span (parser:toplevel-define-instance-head-src instance)
-                         :file file
-                         :message "Overlapping instance"
-                         :primary-note (format nil "instance overlaps with ~S" (tc:overlapping-instance-error-inst2 e))))))
+                   :location (parser:toplevel-define-instance-head-src instance)
+                   
+                   :message "Overlapping instance"
+                   :primary-note (format nil "instance overlaps with ~S" (tc:overlapping-instance-error-inst2 e)))))
 
         (loop :for method-name :in method-names
               :for method-codegen-sym := (gethash method-name method-codegen-syms) :do
@@ -162,11 +160,11 @@
 
         (values instance-entry env)))))
 
-(defun typecheck-instance (instance unparsed-instance env file)
+(defun typecheck-instance (instance unparsed-instance env)
   (declare (type tc:ty-class-instance instance)
            (type parser:toplevel-define-instance unparsed-instance)
            (type tc:environment env)
-           (type coalton-file file))
+           )
 
   (let* ((pred (tc:ty-class-instance-predicate instance))
 
@@ -199,12 +197,11 @@
                     superclass
                     :no-error t)
                    (error 'tc-error
-                          :err (coalton-error
-                                :span (parser:toplevel-define-instance-head-src unparsed-instance)
-                                :file file
-                                :message "Instance missing context"
-                                :primary-note (format nil "No instance for ~S"
-                                                      superclass))))
+                          :location (parser:toplevel-define-instance-head-src unparsed-instance)
+                          
+                          :message "Instance missing context"
+                          :primary-note (format nil "No instance for ~S"
+                                                superclass)))
 
           :for additional-context
             := (tc:apply-substitution
@@ -216,15 +213,14 @@
           :do (loop :for pred :in additional-context
                     :do (unless (tc:entail env context pred)
                           (error 'tc-error
-                                 :err (coalton-error
-                                       :span (parser:toplevel-define-instance-head-src unparsed-instance)
-                                       :file file
-                                       :message "Instance missing context"
-                                       :primary-note
-                                       (format nil
-                                               "No instance for ~S arising from constraints of superclasses ~S"
-                                               pred
-                                               superclass))))))
+                                 :location (parser:toplevel-define-instance-head-src unparsed-instance)
+                                 
+                                 :message "Instance missing context"
+                                 :primary-note
+                                 (format nil
+                                         "No instance for ~S arising from constraints of superclasses ~S"
+                                         pred
+                                         superclass)))))
 
     (check-duplicates
      (parser:toplevel-define-instance-methods unparsed-instance)
@@ -232,17 +228,16 @@
      #'parser:instance-method-definition-source
      (lambda (first second)
        (error 'tc-error
-              :err (coalton-error
-                    :span (parser:instance-method-definition-source first)
-                    :file file
-                    :message "Duplicate method definition"
-                    :primary-note "first definition here"
-                    :notes
-                    (list
-                     (make-coalton-error-note
-                      :type :primary
-                      :span (parser:instance-method-definition-source second)
-                      :message "second definition here"))))))
+              :location (parser:instance-method-definition-source first)
+              
+              :message "Duplicate method definition"
+              :primary-note "first definition here"
+              :notes
+              (list
+               (source-error:make-note
+                :type :primary
+                :location (parser:instance-method-definition-source second)
+                :message "second definition here")))))
 
     ;; Ensure each method is part for the class
     (loop :for method :in (parser:toplevel-define-instance-methods unparsed-instance)
@@ -250,14 +245,13 @@
 
           :unless (gethash name method-table)
             :do (error 'tc-error
-                       :err (coalton-error
-                             :span (parser:instance-method-definition-source method)
-                             :file file
-                             :message "Unknown method"
-                             :primary-note (let ((*package* util:+keyword-package+))
-                                             (format nil "The method ~S is not part of class ~S"
-                                                     name
-                                                     class-name)))))
+                       :location (parser:instance-method-definition-source method)
+                       
+                       :message "Unknown method"
+                       :primary-note (let ((*package* util:+keyword-package+))
+                                       (format nil "The method ~S is not part of class ~S"
+                                               name
+                                               class-name))))
 
     ;; Ensure each method is defined
     (loop :for name :being :the :hash-keys :of method-table
@@ -266,12 +260,11 @@
                                                         #'parser:instance-method-definition-name))
           :unless method
             :do (error 'tc-error
-                       :err (coalton-error
-                             :span (parser:toplevel-define-instance-source unparsed-instance)
-                             :file file
-                             :message "Missing method"
-                             :primary-note (format nil "The method ~S is not defined"
-                                                   name))))
+                       :location (parser:toplevel-define-instance-source unparsed-instance)
+                       
+                       :message "Missing method"
+                       :primary-note (format nil "The method ~S is not defined"
+                                             name)))
 
     (let* ((methods (loop :with table := (make-hash-table :test #'eq)
 
@@ -297,7 +290,7 @@
                                                            (parser:instance-method-definition-source method)
                                                            nil
                                                            (make-tc-env :env env)
-                                                           file)
+                                                           )
 
                                 ;; Deferred predicates should always be null
                                 (unless (null preds)
@@ -325,9 +318,9 @@
        :source (parser:toplevel-define-instance-source unparsed-instance)
        :head-src (parser:toplevel-define-instance-head-src unparsed-instance)))))
 
-(defun check-instance-valid (instance file)
+(defun check-instance-valid (instance)
   (declare (type parser:toplevel-define-instance instance)
-           (type coalton-file file))
+           )
 
   ;; Instance validation is disabled for compiler generated instances
   (when (parser:toplevel-define-instance-compiler-generated instance)
@@ -344,15 +337,13 @@
 
     (when (eq (parser:identifier-src-name (parser:ty-predicate-class (parser:toplevel-define-instance-pred instance))) runtime-repr)
       (error 'tc-error
-             :err (coalton-error
-                   :span (parser:toplevel-define-instance-head-src instance)
-                   :file file
-                   :message "Invalid instance"
-                   :primary-note "RuntimeRepr instances cannot be written manually")))))
+             :location (parser:toplevel-define-instance-head-src instance)
+             
+             :message "Invalid instance"
+             :primary-note "RuntimeRepr instances cannot be written manually"))))
 
-(defun check-for-orphan-instance (instance file)
+(defun check-for-orphan-instance (instance)
   (declare (type parser:toplevel-define-instance instance) 
-           (type coalton-file file)
            (values null))
 
 
@@ -391,8 +382,7 @@
 
     (unless (find *package* instance-syms :key #'symbol-package)
       (error 'tc-error
-             :err (coalton-error
-                   :span (parser:toplevel-define-instance-head-src instance)
-                   :file file
-                   :message "Invalid orphan instance"
-                   :primary-note "instances must be defined in the same package as their class or reference one or more types in their defining package")))))
+             :location (parser:toplevel-define-instance-head-src instance)
+             
+             :message "Invalid orphan instance"
+             :primary-note "instances must be defined in the same package as their class or reference one or more types in their defining package"))))

--- a/src/typechecker/define-type.lisp
+++ b/src/typechecker/define-type.lisp
@@ -63,10 +63,9 @@
 (deftype type-definition-list ()
   '(satisfies type-definition-list-p))
 
-(defun toplevel-define-type (types structs file env)
+(defun toplevel-define-type (types structs env)
   (declare (type parser:toplevel-define-type-list types)
            (type parser:toplevel-define-struct-list structs)
-           (type coalton-file file)
            (type tc:environment env)
            (values type-definition-list parser:toplevel-define-instance-list tc:environment))
 
@@ -74,15 +73,13 @@
   (check-package
    (append types structs)
    (alexandria:compose #'parser:identifier-src-name #'parser:type-definition-name)
-   (alexandria:compose #'parser:identifier-src-source #'parser:type-definition-name)
-   file)
+   (alexandria:compose #'parser:identifier-src-source #'parser:type-definition-name))
 
   ;; Ensure that all constructors are defined in the current package
   (check-package
    (mapcan (alexandria:compose #'copy-list #'parser:toplevel-define-type-ctors) types)
    (alexandria:compose #'parser:identifier-src-name #'parser:constructor-name)
-   (alexandria:compose #'parser:identifier-src-source #'parser:constructor-name)
-   file)
+   (alexandria:compose #'parser:identifier-src-source #'parser:constructor-name))
 
   ;; Ensure that there are no duplicate type definitions
   (check-duplicates
@@ -91,17 +88,16 @@
    #'parser:type-definition-source
    (lambda (first second)
      (error 'tc-error
-            :err (coalton-error
-                  :span (parser:type-definition-source first)
-                  :file file
-                  :message "Duplicate type definitions"
-                  :primary-note "first definition here"
-                  :notes
-                  (list
-                   (make-coalton-error-note
-                    :type :primary
-                    :span (parser:type-definition-source second)
-                    :message "second definition here"))))))
+            :location (parser:type-definition-source first)
+            
+            :message "Duplicate type definitions"
+            :primary-note "first definition here"
+            :notes
+            (list
+             (source-error:make-note
+              :type :primary
+              :location (parser:type-definition-source second)
+              :message "second definition here")))))
 
   ;; Ensure that there are no duplicate constructors
   ;; NOTE: structs define a constructor with the same name
@@ -112,16 +108,15 @@
    #'parser:type-definition-ctor-source
    (lambda (first second)
      (error 'tc-error
-            :err (coalton-error
-                  :span (parser:type-definition-ctor-source first)
-                  :file file
-                  :message "Duplicate constructor definitions"
-                  :primary-note "first definition here"
-                  :notes
-                  (list (make-coalton-error-note
-                         :type :primary
-                         :span (parser:type-definition-ctor-source second)
-                         :message "second definition here"))))))
+            :location (parser:type-definition-ctor-source first)
+            
+            :message "Duplicate constructor definitions"
+            :primary-note "first definition here"
+            :notes
+            (list (source-error:make-note
+                   :type :primary
+                   :location (parser:type-definition-ctor-source second)
+                   :message "second definition here")))))
 
   ;; Ensure that no type has duplicate type variables
   (loop :for type :in (append types structs)
@@ -131,16 +126,15 @@
              #'parser:keyword-src-source
              (lambda (first second)
                (error 'tc-error
-                      :err (coalton-error
-                            :span (parser:keyword-src-source first)
-                            :file file
-                            :message "Duplicate type variable definitions"
-                            :primary-note "first definition here"
-                            :notes
-                            (list (make-coalton-error-note
-                                   :type :primary
-                                   :span (parser:keyword-src-source second)
-                                   :message "second definition here")))))))
+                      :location (parser:keyword-src-source first)
+                      
+                      :message "Duplicate type variable definitions"
+                      :primary-note "first definition here"
+                      :notes
+                      (list (source-error:make-note
+                             :type :primary
+                             :location (parser:keyword-src-source second)
+                             :message "second definition here"))))))
 
   (let* ((type-names (mapcar (alexandria:compose #'parser:identifier-src-name
                                                  #'parser:type-definition-name)
@@ -191,7 +185,7 @@
                      :do (partial-type-env-add-type partial-env name ty))
 
            :append  (multiple-value-bind (type-definitions instances_ ksubs)
-                        (infer-define-type-scc-kinds scc partial-env file)
+                        (infer-define-type-scc-kinds scc partial-env)
                       (setf instances (append instances instances_))
                       (loop :for type :in type-definitions
 
@@ -313,10 +307,9 @@
 
   env)
 
-(defun infer-define-type-scc-kinds (types env file)
+(defun infer-define-type-scc-kinds (types env)
   (declare (type parser:type-definition-list types)
            (type partial-type-env env)
-           (type coalton-file file)
            (values type-definition-list parser:toplevel-define-instance-list))
 
   (let ((ksubs nil)
@@ -330,7 +323,7 @@
                     :for ctor-name := (parser:identifier-src-name (parser:type-definition-ctor-name ctor))
                     :for fields := (loop :for field :in (parser:type-definition-ctor-field-types ctor)
                                          :collect (multiple-value-bind (type ksubs_)
-                                                      (infer-type-kinds field tc:+kstar+ ksubs env file)
+                                                      (infer-type-kinds field tc:+kstar+ ksubs env)
                                                     (setf ksubs ksubs_)
                                                     type))
                     :do (setf (gethash ctor-name ctor-table) fields)))
@@ -356,8 +349,7 @@
                                       (partial-type-env-lookup-var
                                        env
                                        (parser:keyword-src-name var)
-                                       (parser:keyword-src-source var)
-                                       file))
+                                       (parser:keyword-src-source var)))
                                     (parser:type-definition-vars type)))
 
              :for repr := (parser:type-definition-repr type)
@@ -377,41 +369,38 @@
                         :collect (tc:quantify-using-tvar-order tvars (tc:qualify nil ty)))
 
              :for constructor-args
-              := (loop :for ctor :in (parser:type-definition-ctors type)
-                       :for ctor-name := (parser:identifier-src-name (parser:type-definition-ctor-name ctor))
-                       :collect (tc:apply-ksubstitution ksubs (gethash ctor-name ctor-table)))
+               := (loop :for ctor :in (parser:type-definition-ctors type)
+                        :for ctor-name := (parser:identifier-src-name (parser:type-definition-ctor-name ctor))
+                        :collect (tc:apply-ksubstitution ksubs (gethash ctor-name ctor-table)))
 
              ;; Check that repr :enum types do not have any constructors with fields
              :when (eq repr-type :enum)
                :do (loop :for ctor :in (parser:toplevel-define-type-ctors type)
                          :unless (endp (parser:constructor-fields ctor))
                            :do (error 'tc-error
-                                      :err (coalton-error
-                                            :span (parser:ty-source (first (parser:constructor-fields ctor)))
-                                            :file file
-                                            :message "Invalid repr :enum attribute"
-                                            :primary-note "constructors of repr :enum types cannot have fields")))
+                                      :location (parser:ty-source (first (parser:constructor-fields ctor)))
+                                      
+                                      :message "Invalid repr :enum attribute"
+                                      :primary-note "constructors of repr :enum types cannot have fields"))
 
                    ;; Check that repr :transparent types have a single constructor
              :when (eq repr-type :transparent)
                :do (unless (= 1 (length (parser:type-definition-ctors type)))
                      (error 'tc-error
-                            :err (coalton-error
-                                  :span (parser:toplevel-define-type-source type)
-                                  :file file
-                                  :message "Invalid repr :transparent attribute"
-                                  :primary-note "repr :transparent types must have a single constructor")))
+                            :location (parser:toplevel-define-type-source type)
+                            
+                            :message "Invalid repr :transparent attribute"
+                            :primary-note "repr :transparent types must have a single constructor"))
 
                    
                    ;; Check that the single constructor of a repr :transparent type has a single field
              :when (eq repr-type :transparent)
                :do (unless (= 1 (length (parser:type-definition-ctor-field-types (first (parser:type-definition-ctors type)))))
                      (error 'tc-error
-                            :err (coalton-error
-                                  :span (parser:type-definition-ctor-source (first (parser:type-definition-ctors type)))
-                                  :file file
-                                  :message "Invalid repr :transparent attribute"
-                                  :primary-note "constructors of repr :transparent types must have a single field")))
+                            :location (parser:type-definition-ctor-source (first (parser:type-definition-ctors type)))
+                            
+                            :message "Invalid repr :transparent attribute"
+                            :primary-note "constructors of repr :transparent types must have a single field"))
 
              :collect (let* ((ctors
                                (loop :for ctor :in (parser:type-definition-ctors type)

--- a/src/typechecker/entry.lisp
+++ b/src/typechecker/entry.lisp
@@ -19,23 +19,19 @@
 
          (program (parser:rename-variables program))
 
-         (file (parser:program-file program))
-
          (env *global-environment*))
 
     (multiple-value-bind (type-definitions env)
-        (tc:toplevel-define-type (parser:program-types program) file env)
+        (tc:toplevel-define-type (parser:program-types program) env)
       (declare (ignore type-definitions))
 
       (multiple-value-bind (class-definitions env)
           (tc:toplevel-define-class (parser:program-classes program)
-                                 file
-                                 env)
+                                    env)
         (declare (ignore class-definitions))
 
         (setf env (tc:toplevel-define (parser:program-defines program)
-                                   (parser:program-declares program)
-                                   file
-                                   env))
+                                      (parser:program-declares program)
+                                      env))
 
         (values)))))

--- a/src/typechecker/parse-type.lisp
+++ b/src/typechecker/parse-type.lisp
@@ -30,10 +30,9 @@
 ;;; Entrypoints
 ;;;
 
-(defun parse-type (ty env file)
+(defun parse-type (ty env)
   (declare (type parser:ty ty)
            (type tc:environment env)
-           (type coalton-file file)
            (values tc:ty &optional))
 
   (let ((tvars (parser:collect-type-variables ty))
@@ -45,20 +44,15 @@
           :do (partial-type-env-add-var partial-env tvar-name))
 
     (multiple-value-bind (ty ksubs)
-        (infer-type-kinds ty
-                          tc:+kstar+
-                          nil
-                          partial-env
-                          file)
+        (infer-type-kinds ty tc:+kstar+ nil partial-env)
 
       (setf ty (tc:apply-ksubstitution ksubs ty))
       (setf ksubs (tc:kind-monomorphize-subs (tc:kind-variables ty) ksubs))
       (tc:apply-ksubstitution ksubs ty))))
 
-(defun parse-qualified-type (unparsed-ty env file)
+(defun parse-qualified-type (unparsed-ty env)
   (declare (type parser:qualified-ty unparsed-ty)
            (type tc:environment env)
-           (type coalton-file file)
            (values tc:qualified-ty &optional))
 
   (let ((tvars (parser:collect-type-variables unparsed-ty))
@@ -70,7 +64,7 @@
           :do (partial-type-env-add-var partial-env tvar-name))
 
     (multiple-value-bind (qual-ty ksubs)
-        (infer-type-kinds unparsed-ty tc:+kstar+ nil partial-env file)
+        (infer-type-kinds unparsed-ty tc:+kstar+ nil partial-env)
 
       (setf qual-ty (tc:apply-ksubstitution ksubs qual-ty))
       (setf ksubs (tc:kind-monomorphize-subs (tc:kind-variables qual-ty) ksubs))
@@ -81,28 +75,26 @@
 
              (ty (tc:qualified-ty-type qual-ty)))
 
-        (check-for-ambiguous-variables preds ty unparsed-ty file env)
-        (check-for-reducable-context preds unparsed-ty file env)
+        (check-for-ambiguous-variables preds ty unparsed-ty env)
+        (check-for-reducable-context preds unparsed-ty env)
 
         qual-ty))))
 
-(defun parse-ty-scheme (ty env file)
+(defun parse-ty-scheme (ty env)
   (declare (type parser:qualified-ty ty)
            (type tc:environment env)
-           (type coalton-file file)
            (values tc:ty-scheme &optional))
 
-  (let* ((qual-ty (parse-qualified-type ty env file))
+  (let* ((qual-ty (parse-qualified-type ty env))
 
          (tvars (tc:type-variables qual-ty)))
 
     (tc:quantify tvars qual-ty)))
 
-(defun check-for-ambiguous-variables (preds type qual-ty file env)
+(defun check-for-ambiguous-variables (preds type qual-ty env)
   (declare (type tc:ty-predicate-list preds)
            (type tc:ty type)
            (type parser:qualified-ty qual-ty)
-           (type coalton-file file)
            (type tc:environment env))
 
   (let* ((old-unambiguous-vars (tc:type-variables type))
@@ -135,51 +127,44 @@
              (single-variable (= 1 (length ambiguous-vars))))
 
         (error 'tc-error
-               :err (coalton-error
-                     :span (parser:qualified-ty-source qual-ty)
-                     :file file
-                     :message "Invalid qualified type"
-                     :primary-note (format nil "The type ~A ~{~S ~}ambiguous in the type ~S"
-                                           (if single-variable
-                                               "variable is"
-                                               "variables are")
-                                           ambiguous-vars
-                                           (tc:make-qualified-ty
-                                            :predicates preds
-                                            :type type))))))))
+               :location (parser:qualified-ty-source qual-ty)
+               
+               :message "Invalid qualified type"
+               :primary-note (format nil "The type ~A ~{~S ~}ambiguous in the type ~S"
+                                     (if single-variable
+                                         "variable is"
+                                         "variables are")
+                                     ambiguous-vars
+                                     (tc:make-qualified-ty
+                                      :predicates preds
+                                      :type type)))))))
 
-(defun check-for-reducable-context (preds qual-ty file env)
+(defun check-for-reducable-context (preds qual-ty env)
   (declare (type tc:ty-predicate-list preds)
            (type parser:qualified-ty qual-ty)
-           (type coalton-file file)
            (type tc:environment env))
   (let ((reduced-preds (tc:reduce-context env preds nil)))
     (unless (null (set-exclusive-or preds reduced-preds :test #'tc:type-predicate=))
-      (warn 'error:coalton-base-warning
-             :err (coalton-error
-                   :type :warn
-                   :span (parser:qualified-ty-source qual-ty)
-                   :file file
-                   :message "Declared context can be reduced"
-                   :primary-note (if (null reduced-preds)
-                                     "declared predicates are redundant"
-                                     (format nil "context can be reduced to ~{ ~S~}"
-                                             reduced-preds)))))))
+      (warn 'error:coalton-warning
+            :location (parser:qualified-ty-source qual-ty)
+            :message "Declared context can be reduced"
+            :primary-note (if (null reduced-preds)
+                              "declared predicates are redundant"
+                              (format nil "context can be reduced to ~{ ~S~}"
+                                      reduced-preds))))))
 
 ;;;
 ;;; Kind Inference
 ;;;
 
-(defgeneric infer-type-kinds (type expected-kind ksubs env file)
-  (:method ((type parser:tyvar) expected-kind ksubs env file)
+(defgeneric infer-type-kinds (type expected-kind ksubs env)
+  (:method ((type parser:tyvar) expected-kind ksubs env)
     (declare (type tc:kind expected-kind)
-             (type tc:ksubstitution-list ksubs)
-             (type coalton-file file))
+             (type tc:ksubstitution-list ksubs))
     (let* ((tvar (partial-type-env-lookup-var
                   env
                   (parser:tyvar-name type)
-                  (parser:ty-source type)
-                  file))
+                  (parser:ty-source type)))
 
            (kvar (tc:kind-of tvar)))
 
@@ -191,41 +176,37 @@
             (values (tc:apply-ksubstitution ksubs tvar) ksubs))
         (error:coalton-internal-type-error ()
           (error 'tc-error
-                 :err (coalton-error
-                       :span (parser:ty-source type)
-                       :file file
-                       :message "Kind mismatch"
-                       :primary-note (format nil "Expected kind '~S' but variable is of kind '~S'"
-                                             expected-kind
-                                             kvar)))))))
+                 :location (parser:ty-source type)
+                 
+                 :message "Kind mismatch"
+                 :primary-note (format nil "Expected kind '~S' but variable is of kind '~S'"
+                                       expected-kind
+                                       kvar))))))
 
-  (:method ((type parser:tycon) expected-kind ksubs env file)
+  (:method ((type parser:tycon) expected-kind ksubs env)
     (declare (type tc:kind expected-kind)
              (type tc:ksubstitution-list ksubs)
              (type partial-type-env env)
-             (type coalton-file file)
              (values tc:ty tc:ksubstitution-list))
 
-    (let ((type_ (partial-type-env-lookup-type env type file)))
+    (let ((type_ (partial-type-env-lookup-type env type)))
       (handler-case
           (progn
             (setf ksubs (tc:kunify (tc:kind-of type_) expected-kind ksubs))
             (values (tc:apply-ksubstitution ksubs type_) ksubs))
         (error:coalton-internal-type-error ()
           (error 'tc-error
-                 :err (coalton-error
-                       :span (parser:ty-source type)
-                       :file file
-                       :message "Kind mismatch"
-                       :primary-note (format nil "Expected kind '~S' but got kind '~S'"
-                                             expected-kind
-                                             (tc:kind-of type_))))))))
+                 :location (parser:ty-source type)
+                 
+                 :message "Kind mismatch"
+                 :primary-note (format nil "Expected kind '~S' but got kind '~S'"
+                                       expected-kind
+                                       (tc:kind-of type_)))))))
 
-  (:method ((type parser:tapp) expected-kind ksubs env file)
+  (:method ((type parser:tapp) expected-kind ksubs env)
     (declare (type tc:kind expected-kind)
              (type tc:ksubstitution-list ksubs)
              (type partial-type-env env)
-             (type coalton-file file)
              (values tc:ty tc:ksubstitution-list &optional))
 
     (let ((fun-kind (tc:make-kvariable))
@@ -233,7 +214,7 @@
           (arg-kind (tc:make-kvariable)))
 
       (multiple-value-bind (fun-ty ksubs)
-          (infer-type-kinds (parser:tapp-from type) fun-kind ksubs env file)
+          (infer-type-kinds (parser:tapp-from type) fun-kind ksubs env)
 
         (setf fun-kind (tc:apply-ksubstitution ksubs fun-kind))
 
@@ -243,7 +224,7 @@
           (setf arg-kind (tc:apply-ksubstitution ksubs arg-kind)))
 
         (multiple-value-bind (arg-ty ksubs)
-            (infer-type-kinds (parser:tapp-to type) arg-kind ksubs env file)
+            (infer-type-kinds (parser:tapp-to type) arg-kind ksubs env)
 
           (handler-case
               (progn
@@ -253,21 +234,19 @@
                  ksubs))
             (error:coalton-internal-type-error ()
               (error 'tc-error
-                     :err (coalton-error
-                           :span (parser:ty-source (parser:tapp-from type))
-                           :file file
-                           :message "Kind mismatch"
-                           :primary-note (format nil "Expected kind '~S' but got kind '~S'"
-                                                 (tc:make-kfun
-                                                  :from (tc:apply-ksubstitution ksubs arg-kind)
-                                                  :to (tc:apply-ksubstitution ksubs expected-kind))
-                                                 (tc:apply-ksubstitution ksubs fun-kind))))))))))
+                     :location (parser:ty-source (parser:tapp-from type))
+                     
+                     :message "Kind mismatch"
+                     :primary-note (format nil "Expected kind '~S' but got kind '~S'"
+                                           (tc:make-kfun
+                                            :from (tc:apply-ksubstitution ksubs arg-kind)
+                                            :to (tc:apply-ksubstitution ksubs expected-kind))
+                                           (tc:apply-ksubstitution ksubs fun-kind)))))))))
 
-  (:method ((type parser:qualified-ty) expected-kind ksubs env file)
+  (:method ((type parser:qualified-ty) expected-kind ksubs env)
     (declare (type tc:kind expected-kind)
              (type tc:ksubstitution-list ksubs)
              (type partial-type-env env)
-             (type coalton-file file)
              (values tc:qualified-ty tc:ksubstitution-list))
     
     ;; CCL >:(
@@ -278,8 +257,7 @@
                                     (infer-predicate-kinds
                                      pred
                                      ksubs
-                                     env
-                                     file)
+                                     env)
                                   (setf ksubs ksubs_)
                                   pred))))
 
@@ -287,8 +265,7 @@
           (infer-type-kinds (parser:qualified-ty-type type)
                             tc:+kstar+
                             ksubs
-                            env
-                            file)
+                            env)
 
         (values
          (tc:make-qualified-ty
@@ -296,29 +273,27 @@
           :type ty)
          ksubs)))))
 
-(defun infer-predicate-kinds (pred ksubs env file)
+(defun infer-predicate-kinds (pred ksubs env)
   (declare (type parser:ty-predicate pred)
            (type tc:ksubstitution-list ksubs)
            (type partial-type-env env)
-           (type coalton-file file)
            (values tc:ty-predicate tc:ksubstitution-list))
 
   (let* ((class-name (parser:identifier-src-name (parser:ty-predicate-class pred)))
 
-         (class-pred (partial-type-env-lookup-class env pred file))
+         (class-pred (partial-type-env-lookup-class env pred))
 
          (class-arity (length (tc:ty-predicate-types class-pred))))
 
     ;; Check that pred has the correct number of arguments
     (unless (= class-arity (length (parser:ty-predicate-types pred)))
       (error 'tc-error
-             :err (coalton-error
-                   :span (parser:ty-predicate-source pred)
-                   :file file
-                   :message "Predicate arity mismatch"
-                   :primary-note (format nil "Expected ~D arguments but received ~D"
-                                         class-arity
-                                         (length (parser:ty-predicate-types pred))))))
+             :location (parser:ty-predicate-source pred)
+             
+             :message "Predicate arity mismatch"
+             :primary-note (format nil "Expected ~D arguments but received ~D"
+                                   class-arity
+                                   (length (parser:ty-predicate-types pred)))))
 
     (let ((types (loop :for ty :in (parser:ty-predicate-types pred)
                        :for class-ty :in (tc:ty-predicate-types class-pred)
@@ -326,8 +301,7 @@
                                     (infer-type-kinds ty
                                                       (tc:kind-of class-ty)
                                                       ksubs
-                                                      env
-                                                      file)
+                                                      env)
                                   (setf ksubs ksubs_)
                                   ty))))
       (values

--- a/src/typechecker/partial-type-env.lisp
+++ b/src/typechecker/partial-type-env.lisp
@@ -40,23 +40,20 @@
 
   (setf (gethash var (partial-type-env-ty-table env)) (tc:make-variable (tc:make-kvariable))))
 
-(defun partial-type-env-lookup-var (env var source file)
+(defun partial-type-env-lookup-var (env var source)
   (declare (type partial-type-env env)
            (type symbol var)
            (type cons source)
-           (type coalton-file file)
            (values tc:tyvar))
 
   (let ((ty (gethash var (partial-type-env-ty-table env))))
 
     (unless ty
       (error 'tc-error
-             :err (coalton-error
-                   :span source
-                   :file file
-                   :message "Unknown type variable"
-                   :primary-note (format nil "Unknown type variable ~S"
-                                         var))))
+             :location source
+             :message "Unknown type variable"
+             :primary-note (format nil "Unknown type variable ~S"
+                                   var)))
 
     ty))
 
@@ -84,10 +81,9 @@
   (setf (gethash name (partial-type-env-ty-table env)) type)
   nil)
 
-(defun partial-type-env-lookup-type (env tycon file)
+(defun partial-type-env-lookup-type (env tycon)
   (declare (type partial-type-env env)
            (type parser:tycon tycon)
-           (type coalton-file file)
            (values tc:ty))
   
   (let* ((name (parser:tycon-name tycon))
@@ -101,11 +97,9 @@
 
       (unless type-entry
         (error 'tc-error
-               :err (coalton-error
-                     :span (parser:ty-source tycon)
-                     :file file
-                     :message "Unknown type"
-                     :primary-note (format nil "unknown type ~S" (parser:tycon-name tycon)))))
+               :location (parser:ty-source tycon)
+               :message "Unknown type"
+               :primary-note (format nil "unknown type ~S" (parser:tycon-name tycon))))
 
       (tc:type-entry-type type-entry))))
 
@@ -120,10 +114,9 @@
   (setf (gethash (tc:ty-predicate-class pred) (partial-type-env-class-table env)) pred)
   nil)
 
-(defun partial-type-env-lookup-class (env pred file)
+(defun partial-type-env-lookup-class (env pred)
   (declare (type partial-type-env env)
            (type parser:ty-predicate pred)
-           (type coalton-file file)
            (values tc:ty-predicate))
 
   (let* ((name (parser:identifier-src-name (parser:ty-predicate-class pred)))
@@ -137,12 +130,10 @@
 
       (unless class-entry
         (error 'tc-error
-               :err (coalton-error
-                     :span (parser:ty-predicate-source pred)
-                     :file file
-                     :message "Unknown class"
-                     :primary-note (format nil "unknown class ~S"
-                                           (parser:identifier-src-name
-                                            (parser:ty-predicate-class pred))))))
+               :location (parser:ty-predicate-source pred)
+               :message "Unknown class"
+               :primary-note (format nil "unknown class ~S"
+                                     (parser:identifier-src-name
+                                      (parser:ty-predicate-class pred)))))
 
       (tc:ty-class-predicate class-entry))))

--- a/src/typechecker/specialize.lisp
+++ b/src/typechecker/specialize.lisp
@@ -13,22 +13,20 @@
 
 (in-package #:coalton-impl/typechecker/specialize)
 
-(defun toplevel-specialize (specializations env file)
+(defun toplevel-specialize (specializations env)
 
   (declare (type parser:toplevel-specialize-list specializations)
            (type tc:environment env)
-           (type error:coalton-file file)
            (values tc:environment))
 
   (loop :for spec :in specializations :do
-    (setf env (process-specialize spec env file)))
+    (setf env (process-specialize spec env)))
 
   env)
 
-(defun process-specialize (specialize env file)
+(defun process-specialize (specialize env)
   (declare (type parser:toplevel-specialize specialize)
            (type tc:environment env)
-           (type error:coalton-file file)
            (values tc:environment &optional))
 
   (let* ((from-name (parser:node-variable-name (parser:toplevel-specialize-from specialize)))
@@ -40,76 +38,68 @@
          (from-name-entry (tc:lookup-name env from-name :no-error t))
          (to-name-entry (tc:lookup-name env to-name :no-error t))
 
-         (type (parse-type (parser:toplevel-specialize-type specialize) env file))
+         (type (parse-type (parser:toplevel-specialize-type specialize) env))
          (scheme (tc:quantify (tc:type-variables type)
                               (tc:qualify nil type))))
 
     (unless from-ty
       (error 'tc-error
-             :err (coalton-error
-                   :span (parser:node-source (parser:toplevel-specialize-from specialize))
-                   :file file
-                   :message "Invalid specialization"
-                   :primary-note "unknown function or variable")))
+             :location (parser:node-source (parser:toplevel-specialize-from specialize))
+             
+             :message "Invalid specialization"
+             :primary-note "unknown function or variable"))
     (unless to-ty
       (error 'tc-error
-             :err (coalton-error
-                   :span (parser:node-source (parser:toplevel-specialize-to specialize))
-                   :file file
-                   :message "Invalid specialization"
-                   :primary-note "unknown function or variable")))
+             :location (parser:node-source (parser:toplevel-specialize-to specialize))
+             
+             :message "Invalid specialization"
+             :primary-note "unknown function or variable"))
 
     (unless (eq :value (tc:name-entry-type from-name-entry))
       (error 'tc-error
-             :err (coalton-error
-                   :span (parser:node-source (parser:toplevel-specialize-from specialize))
-                   :file file
-                   :message "Invalid specialization"
-                   :primary-note (format nil "must be a function or variable, not a ~A" (tc:name-entry-type from-name-entry)))))
+             :location (parser:node-source (parser:toplevel-specialize-from specialize))
+             
+             :message "Invalid specialization"
+             :primary-note (format nil "must be a function or variable, not a ~A" (tc:name-entry-type from-name-entry))))
     (unless (eq :value (tc:name-entry-type to-name-entry))
       (error 'tc-error
-             :err (coalton-error
-                   :span (parser:node-source (parser:toplevel-specialize-to specialize))
-                   :file file
-                   :message "Invalid specialization"
-                   :primary-note (format nil "must be a function or variable, not a ~A" (tc:name-entry-type from-name-entry)))))
+             :location (parser:node-source (parser:toplevel-specialize-to specialize))
+             
+             :message "Invalid specialization"
+             :primary-note (format nil "must be a function or variable, not a ~A" (tc:name-entry-type from-name-entry))))
 
     (let ((from-qual-ty (tc:fresh-inst from-ty))
           (to-qual-ty (tc:fresh-inst to-ty)))
 
       (when (null (tc:qualified-ty-predicates from-qual-ty))
         (error 'tc-error
-               :err (coalton-error
-                     :span (parser:node-source (parser:toplevel-specialize-from specialize))
-                     :file file
-                     :message "Invalid specialization"
-                     :primary-note "must be a function or variable with class constraints")))
+               :location (parser:node-source (parser:toplevel-specialize-from specialize))
+               
+               :message "Invalid specialization"
+               :primary-note "must be a function or variable with class constraints"))
 
       (unless (equalp to-ty scheme)
         (error 'tc-error
-               :err (coalton-error
-                     :span (parser:toplevel-specialize-source specialize)
-                     :file file
-                     :message "Invalid specialization"
-                     :primary-note (format nil "function ~S does not match declared type" to-name))))
+               :location (parser:toplevel-specialize-source specialize)
+               
+               :message "Invalid specialization"
+               :primary-note (format nil "function ~S does not match declared type" to-name)))
 
       (when (equalp from-ty to-ty)
         (error 'tc-error
-               :err (coalton-error
-                     :span (parser:toplevel-specialize-source specialize)
-                     :file file
-                     :message "Invalid specialization"
-                     :primary-note "specialize must result in a more specific type")))
+               :location (parser:toplevel-specialize-source specialize)
+               
+               :message "Invalid specialization"
+               :primary-note "specialize must result in a more specific type"))
 
       (handler-case
           (tc:match (tc:qualified-ty-type from-qual-ty) (tc:qualified-ty-type to-qual-ty))
         (error:coalton-internal-type-error ()
           (error 'tc-error
-                 :err (coalton-error
-                       :span (parser:toplevel-specialize-source specialize)
-                       :file file
-                       :message "Invalid specialization"
-                       :primary-note "cannot specialize to declared type"))))
+                 :location (parser:toplevel-specialize-source specialize)
+                 
+                 :message "Invalid specialization"
+                 :primary-note "cannot specialize to declared type")))
 
       (let ((entry (tc:make-specialization-entry
                     :from from-name
@@ -120,8 +110,7 @@
             (tc:add-specialization env entry)
           (tc:overlapping-specialization-error (c)
             (error 'tc-error
-                   :err (coalton-error
-                         :span (parser:toplevel-specialize-source specialize)
-                         :file file
-                         :message "Overlapping specialization"
-                         :primary-note (format nil "overlaps with specialization ~S" (tc:overlapping-specialization-error-existing c))))))))))
+                   :location (parser:toplevel-specialize-source specialize)
+                   
+                   :message "Overlapping specialization"
+                   :primary-note (format nil "overlaps with specialization ~S" (tc:overlapping-specialization-error-existing c)))))))))

--- a/src/typechecker/tc-env.lisp
+++ b/src/typechecker/tc-env.lisp
@@ -5,7 +5,6 @@
    #:coalton-impl/typechecker/parse-type)
   (:local-nicknames
    (#:util #:coalton-impl/util)
-   (#:error #:coalton-impl/error)
    (#:parser #:coalton-impl/parser)
    (#:tc #:coalton-impl/typechecker/stage-1))
   (:export
@@ -47,11 +46,10 @@
 
   (tc:qualified-ty-type (tc:fresh-inst (setf (gethash name (tc-env-ty-table env)) (tc:to-scheme (tc:make-variable))))))
 
-(defun tc-env-lookup-value (env var file)
+(defun tc-env-lookup-value (env var)
   "Lookup a variable named VAR in ENV."
   (declare (type tc-env env)
            (type parser:node-variable var)
-           (type coalton-file file)
            (values tc:ty tc:ty-predicate-list))
 
 
@@ -70,20 +68,18 @@
                                        (coalton-impl/algorithm::immutable-map-keys
                                         (tc:environment-value-environment (tc-env-env env)))))))
                        (error 'tc-error
-                              :err (coalton-error
-                                    :span (parser:node-source var)
-                                    :file file
-                                    :message "Unknown variable"
-                                    :primary-note "unknown variable"
-                                    :help-notes (mapcar
-                                                 (lambda (symbol)
-                                                   (error:make-coalton-error-help
-                                                    :span (parser:node-source var)
-                                                    :replacement (lambda (s)
-                                                                   (declare (ignore s))
-                                                                   (format nil "~S" symbol))
-                                                    :message (format nil "Did you mean ~S?" symbol)))
-                                                 matches))))))
+                              :location (parser:node-source var)
+                              :message "Unknown variable"
+                              :primary-note "unknown variable"
+                              :help-notes (mapcar
+                                           (lambda (symbol)
+                                             (source-error:make-help
+                                              :location (parser:node-source var)
+                                              :replacement (lambda (s)
+                                                             (declare (ignore s))
+                                                             (format nil "~S" symbol))
+                                              :message (format nil "Did you mean ~S?" symbol)))
+                                           matches)))))
 
          (qual-ty (tc:fresh-inst scheme))
 

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -17,7 +17,9 @@
    #:symbol-list                        ; TYPE
    #:string-list                        ; TYPE
    #:cst-list                           ; TYPE
-   #:cst-source-range                   ; FUNCTION
+   #:source-start                       ; FUNCTION
+   #:source-end                         ; FUNCTION
+   #:source-range                       ; FUNCTION
    #:literal-value                      ; TYPE
    #:literal-equal                      ; FUNCTION
    #:maphash-values-new                 ; FUNCTION
@@ -56,12 +58,18 @@
 (deftype cst-list ()
   '(satisfies cst-list-p))
 
-(defun cst-source-range (csts)
+(defun source-start (form)
+  (car (cst:source form)))
+
+(defun source-end (form)
+  (cdr (cst:source form)))
+
+(defun source-range (csts)
   (declare (type cst-list csts)
            (values cons))
   (cons
-   (car (cst:source (first csts)))
-   (cdr (cst:source (car (last csts))))))
+   (source-start (first csts))
+   (source-end (car (last csts)))))
 
 (defmacro debug-log (&rest vars)
   "Log names and values of VARS to standard output"

--- a/tests/error-tests.lisp
+++ b/tests/error-tests.lisp
@@ -30,36 +30,36 @@
                   output-stream)
     :close-stream
     (with-open-file (stream program-file)
-      (let* ((f (coalton-impl/error:make-coalton-ide-file program-file "file" 0))
+      (let* ((source-error:*source* (source-error:make-displaced-source-file program-file "file" 0))
              (msg (with-output-to-string (output)
                     ;; an annotating error
-                    (source-error:print-source-error
-                     output
-                     (coalton-impl/error:coalton-error
-                      :span '(76 . 321)
-                      :file f
+                    (source-error:report-source-condition
+                     (make-instance 'source-error:source-error
+                      :location '(76 . 321)
                       :message "message"
                       :primary-note "define instance form"
                       :notes (list
-                              (coalton-impl/error:make-coalton-error-note
+                              (source-error:make-note
                                :type :secondary
-                               :span  '(132 . 319)
+                               :location  '(132 . 319)
                                :message "message 2")
-                              (coalton-impl/error:make-coalton-error-note
+                              (source-error:make-note
                                :type :secondary
-                               :span  '(140 . 145)
+                               :location  '(140 . 145)
                                :message "message 3")
-                              (coalton-impl/error:make-coalton-error-note
+                              (source-error:make-note
                                :type :secondary
-                               :span  '(170 . 174)
+                               :location  '(170 . 174)
                                :message "message 4"))
                       :help-notes
                       (list
-                       (coalton-impl/error:make-coalton-error-help
-                        :span  '(289 . 291)
+                       (source-error:make-help
+                        :location  '(289 . 291)
                         :replacement (lambda (existing)
                                        (concatenate 'string "*" existing "*"))
-                        :message "message 5")))))))
+                        :message "message 5")))
+                     output))))
+
         ;; output text
         (is (string= msg "error: message
   --> file:9:2

--- a/tests/error-tests.lisp
+++ b/tests/error-tests.lisp
@@ -30,12 +30,12 @@
                   output-stream)
     :close-stream
     (with-open-file (stream program-file)
-      (let* ((f (coalton-impl/error::make-coalton-file :stream stream :name "file"))
+      (let* ((f (coalton-impl/error:make-coalton-ide-file program-file "file" 0))
              (msg (with-output-to-string (output)
                     ;; an annotating error
-                    (coalton-impl/error::display-coalton-error
+                    (source-error:print-source-error
                      output
-                     (coalton-impl/error::coalton-error
+                     (coalton-impl/error:coalton-error
                       :span '(76 . 321)
                       :file f
                       :message "message"

--- a/tests/parser-tests.lisp
+++ b/tests/parser-tests.lisp
@@ -5,21 +5,22 @@
              (directory (merge-pathnames pattern (asdf:system-source-directory "coalton/tests"))))
 
            (parse-file (file)
-             (with-open-file (stream file
-                                     :direction :input
-                                     :element-type 'character)
+             (source-error:with-source-file (stream file)
                (parser:with-reader-context stream
-                 (parser:read-program stream (error:make-coalton-file :stream stream :name (namestring file)) :mode :file))))
+                 (parser:read-program stream :mode :file))))
+
+           (error-string (condition)
+             (with-output-to-string (stream)
+               (source-error:report-source-condition condition stream)))
 
            (parse-error-text (file)
-             (with-open-file (stream file
-                                     :direction :input
-                                     :element-type 'character)
-               (handler-case
+             (handler-case
+                 (source-error:with-displaced-source-file (stream file "test" 0)
                    (parser:with-reader-context stream
-                     (parser:read-program stream (error:make-coalton-file :stream stream :name "test") :mode :file))
-                 (error:coalton-base-error (c)
-                   (princ-to-string c))))))
+                     (parser:read-program stream :mode :file))
+                   nil)
+               (error:coalton-error (c)
+                 (error-string c)))))
     (dolist (file (test-files "tests/parser/*.bad.coalton"))
       (let ((error-file (make-pathname :type "error"
                                        :defaults file)))

--- a/tests/parser/define-instance.7.bad.error
+++ b/tests/parser/define-instance.7.bad.error
@@ -1,0 +1,5 @@
+error: Malformed instance definition
+  --> test:4:17
+   |
+ 4 |  (define-instance)
+   |                  ^ expected an instance head

--- a/tests/parser/define-type.2.bad.error
+++ b/tests/parser/define-type.2.bad.error
@@ -1,0 +1,8 @@
+error: Invalid type variable
+  --> test:4:16
+   |
+ 4 |  (define-type (T a))
+   |                  ^ expected keyword symbol
+help: add `:` to symbol
+ 4 | (define-type (T :a))
+   |                 --

--- a/tests/parser/parse-attribute.5.bad.error
+++ b/tests/parser/parse-attribute.5.bad.error
@@ -1,0 +1,5 @@
+error: Malformed repr :native attribute
+  --> test:4:14
+   |
+ 4 |  (repr :native)
+   |               ^ expected a lisp type

--- a/tests/parser/toplevel-progn.1.bad.error
+++ b/tests/parser/toplevel-progn.1.bad.error
@@ -1,10 +1,10 @@
 error: Invalid attribute for progn
   --> test:4:0
    |
- 4 |   (repr :transparent)
-   |   ^^^^^^^^^^^^^^^^^^^ progn cannot have attributes
- 5 |   (progn
-   |  _-
- 6 | |   (define-type T
- 7 | |     (T Integer)))
-   | |_________________- when parsing progn
+ 4 |  (repr :transparent)
+   |  ^^^^^^^^^^^^^^^^^^^ progn cannot have attributes
+ 5 |  (progn
+   |  -
+ 6 | |  (define-type T
+ 7 | |    (T Integer)))
+   | |________________- when parsing progn

--- a/tests/utilities.lisp
+++ b/tests/utilities.lisp
@@ -38,10 +38,10 @@
     (unwind-protect
          (let* ((stream (make-string-input-stream toplevel-string))
 
-                (file (error:make-coalton-string toplevel-string))
+                (source-error:*source* (source-error:make-source-string toplevel-string))
 
                 (program (parser:with-reader-context stream
-                           (parser:read-program stream file :mode :test))))
+                           (parser:read-program stream :mode :test))))
 
            (multiple-value-bind (program env)
                (entry:entry-point program)
@@ -50,14 +50,10 @@
              (when expected-types
                (loop :for (unparsed-symbol . unparsed-type) :in expected-types
                      :for symbol := (intern (string-upcase unparsed-symbol) *package*)
-
                      :for stream := (make-string-input-stream unparsed-type)
-                     :for file := (error:make-coalton-string unparsed-type)
-
                      :for ast-type := (parser:parse-qualified-type
-                                       (eclector.concrete-syntax-tree:read stream)
-                                       file)
-                     :for parsed-type := (tc:parse-ty-scheme ast-type env file)
+                                       (eclector.concrete-syntax-tree:read stream))
+                     :for parsed-type := (tc:parse-ty-scheme ast-type env)
                      :do (is (equalp
                               (tc:lookup-value-type env symbol)
                               parsed-type)))))

--- a/tests/utilities.lisp
+++ b/tests/utilities.lisp
@@ -38,7 +38,7 @@
     (unwind-protect
          (let* ((stream (make-string-input-stream toplevel-string))
 
-                (file (error:make-coalton-file :stream stream :name "<test>"))
+                (file (error:make-coalton-string toplevel-string))
 
                 (program (parser:with-reader-context stream
                            (parser:read-program stream file :mode :test))))
@@ -46,13 +46,13 @@
            (multiple-value-bind (program env)
                (entry:entry-point program)
              (declare (ignore program))
-             
+
              (when expected-types
                (loop :for (unparsed-symbol . unparsed-type) :in expected-types
                      :for symbol := (intern (string-upcase unparsed-symbol) *package*)
 
                      :for stream := (make-string-input-stream unparsed-type)
-                     :for file := (error:make-coalton-file :stream stream :name "<unknown>")
+                     :for file := (error:make-coalton-string unparsed-type)
 
                      :for ast-type := (parser:parse-qualified-type
                                        (eclector.concrete-syntax-tree:read stream)


### PR DESCRIPTION
- Integrate the intermediate error implementation class 'coalton-error' into the base condition class defined in source-error.lisp.
- Unthread the `file` argument from parser and typechecker functions

